### PR TITLE
bump compiler to 2021-11-12

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2021-09-29
+        toolchain: nightly-2021-11-12
         components: rustfmt, clippy
         target: wasm32-unknown-unknown
         override: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # The cache for docker container dependency
 /.cargo/config
 
+# Local source crates for testing
+/crates
+
 .DS_Store
 .idea
 .vscode

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly-2021-11-12"
+components = [ "rustfmt", "clippy" ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"


### PR DESCRIPTION
fixes unstable `asm` macro feature, which was causing build fails.  Other projects are just using older compilers, but hopefully we can just bump `wasmtime` to 0.33.0 in substrate modules and use a newer rustc.  This works in the meantime, but I have a decent lead on how to resolve the underlying issue.