### PR TITLE
Declare chain extension in pallet_contracts config

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -522,9 +522,9 @@ impl ChainExtension<Runtime> for BalanceChainExtension {
 		log::info!("Call chain extension: {:?}", func_id,);
 
 		trace!(
-		target: "runtime",
-		"[ChainExtension]|call|func_id:{:}",
-		func_id
+			target: "runtime",
+			"[ChainExtension]|call|func_id:{:}",
+			func_id
 		);
 
 		match func_id {


### PR DESCRIPTION
Fixes the issue of not being able to deploy the pendulum AMM smart contract.
The `BalanceChainExtension` was defined but never used i.e. not declared in the `pallet_contracts` config. Changing l. 888 fixes the issue.