### PR TITLE
#38 bump up nightly version to 1.63

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2021-09-29
+        toolchain: nightly-2022-05-26
         components: rustfmt, clippy
         target: wasm32-unknown-unknown
         override: true

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-11-12"
+channel = "nightly-2022-05-26"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
Also updated the version in test-code.yml, due to:
```
error[E0658]: use of unstable library feature 'proc_macro_is_available'
  --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.36/src/detection.rs:28:21
   |
28 |     let available = proc_macro::is_available();
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #71436 <https://github.com/rust-lang/rust/issues/71436> for more information
   = help: add `#![feature(proc_macro_is_available)]` to the crate attributes to enable
```
All upcoming PRs after this should get a passing test-code check.