### PR TITLE
Add pallet-vesting, pallet-utility and shorten democracy schedules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,8 @@ dependencies = [
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-utility",
+ "pallet-vesting",
  "pallet-xcm",
  "parachain-info",
  "parity-scale-codec",

--- a/README.md
+++ b/README.md
@@ -3,38 +3,51 @@
 Pendulum chain by SatoshiPay. More information about Pendulum can be found [here](https://docs.pendulumchain.org/).
 
 ### How to Run Tests
+
 To run the unit tests, execute
+
 ```
 cargo test
 ```
 
 ### How to Build
+
 To build the project, execute
+
 ```
 cargo build --release
 ```
+
 A successful build will create a binary under `./target/release/parachain-collator`.
 
 ### How to Generate Chain Spec
+
 There are 2 different [runtime](runtime)s currently in the repo; **amplitude** for the Amplitude parachain and **development** for the Pendulum parachain. Any of these runtimes are used depending on the config. The config is created by generating the chain spec:
+
 ```
 ./target/release/parachain-collator build-spec --disable-default-bootnode > local-parachain-plain.json
 ```
+
 To create the amplitude spec, the `--chain` must be provided:
+
 ```
 ./target/release/parachain-collator build-spec --chain amplitude --disable-default-bootnode > local-parachain-plain.json
 ```
 
 For the raw chain spec, just add the option `--raw` and the `--chain` should be the one you just generated:
+
 ```
 ./target/release/parachain-collator build-spec --chain local-parachain-plain.json --raw --disable-default-bootnode > local-parachain-raw.json
 ```
 
 ### How to Generate Wasm:
+
 ```
 /target/release/parachain-collator export-genesis-wasm --chain local-parachain-raw.json > para-2000-wasm
 ```
+
 ### How to Generate Genesis State:
+
 ```
 ./target/release/parachain-collator export-genesis-state --chain local-parachain-raw.json > para-2000-genesis
 ```
@@ -42,7 +55,9 @@ For the raw chain spec, just add the option `--raw` and the `--chain` should be 
 Note: The amplitude chain specs, the wasm and the genesis state are already available in the [res](res) folder.
 
 ### How to Run:
+
 To run the collator, execute:
+
 ```
 ./target/release/parachain-collator
 --collator \
@@ -60,16 +75,18 @@ To run the collator, execute:
 --chain <R_SPEC_RAW.json> \
 --execution=wasm --sync fast --pruning archive
 ```
+
 where:
-| Parachain         | Relay Chain       | Description                              |
+| Parachain | Relay Chain | Description |
 |-------------------|-------------------|------------------------------------------|
-| `ASSIGN_A_NAME`   |                   | assigning a name to the chain            |
-| `P_WS_PORT`       |                   | listening port for WebSocket connections |
-| `P_PORT`          | `R_PORT`          | port for peer-to-peer communication      |
-| `P_RPC_PORT`      |                   | port for remote procedure calls          |
-| `P_SPEC_RAW.json` | `R_SPEC_RAW.json` | raw json file of the chain spec          |
+| `ASSIGN_A_NAME` | | assigning a name to the chain |
+| `P_WS_PORT` | | listening port for WebSocket connections |
+| `P_PORT` | `R_PORT` | port for peer-to-peer communication |
+| `P_RPC_PORT` | | port for remote procedure calls |
+| `P_SPEC_RAW.json` | `R_SPEC_RAW.json` | raw json file of the chain spec |
 
 An example for Amplitude will look like this:
+
 ```
 ./target/release/parachain-collator
 --collator \
@@ -87,9 +104,11 @@ An example for Amplitude will look like this:
 --chain kusama.json \
 --execution=wasm --sync fast --pruning archive
 ```
+
 You can find the kusama.json [here](https://github.com/paritytech/polkadot/blob/master/node/service/chain-specs/kusama.json).
 
-For local testing, you can replace `--name` with predefined keys like `--alice` or `--bob`. You also need to specify the `--bootnode`.  Here's an example:
+For local testing, you can replace `--name` with predefined keys like `--alice` or `--bob`. You also need to specify the `--bootnode`. Here's an example:
+
 ```
 ./target/release/parachain-collator \
 --alice \
@@ -108,7 +127,8 @@ For local testing, you can replace `--name` with predefined keys like `--alice` 
 --port 30343 \
 --ws-port 9977
 ```
+
 where `ALICE_NODE_ID` is the peer id of Alice.
-You can find the rococo-custom-2-raw.json [here](https://github.com/substrate-developer-hub/substrate-docs/blob/main/static/assets/tutorials/cumulus/chain-specs/rococo-custom-2-raw.json).
+You can find the rococo-custom-2-raw.json [here](https://github.com/substrate-developer-hub/substrate-docs/blob/314e9cd3bd0ca9426bbfd381b79c3ef4d06b49c2/static/assets/tutorials/cumulus/chain-specs/rococo-custom-2-raw.json).
 
 There are prerequisites in running the collator with a local relay chain. Refer to [how to run Pendulum locally](https://pendulum.gitbook.io/pendulum-docs/build/running-pendulum-locally).

--- a/runtime/amplitude/Cargo.toml
+++ b/runtime/amplitude/Cargo.toml
@@ -46,6 +46,8 @@ pallet-sudo = {git = "https://github.com/paritytech/substrate", default-features
 pallet-timestamp = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24"}
 pallet-transaction-payment = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24"}
 pallet-transaction-payment-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24"}
+pallet-utility = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24"}
+pallet-vesting = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24"}
 sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24"}
 sp-block-builder = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24"}
 sp-consensus-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24"}
@@ -114,6 +116,8 @@ std = [
   "pallet-timestamp/std",
   "pallet-transaction-payment-rpc-runtime-api/std",
   "pallet-transaction-payment/std",
+  "pallet-utility/std",
+  "pallet-vesting/std",
   "pallet-xcm/std",
   "parachain-info/std",
   "polkadot-parachain/std",


### PR DESCRIPTION
I had to add the standard pallet-vesting instead of orml-vesting because orml-vesting does not allow for force-vested-transfers.

A force-vested-transfer is a vested transfer initiated through governance. This allows to circumvent the call filters we set up. We had to make the normal vested-transfer subject to a call filter because it would allow to transfer money – this is not permitted as long as the democratization is not complete.

Since orml-vesting has only the normal vested-transfer, also governance would not be able to pass this call filter and we would not be able to pay out the crowdloan rewards in the next phase.

I don’t see problems to use pallet-vesting instead of orml-vesting for Amplitude