### PR TITLE
94 orml tokens allowance pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5401,6 +5401,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "mocktopus",
+ "orml-tokens",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ dependencies = [
  "log",
  "orml-currencies",
  "orml-tokens",
+ "orml-tokens-allowance",
  "orml-traits",
  "orml-xtokens",
  "pallet-aura",
@@ -4942,6 +4943,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "mocktopus"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4f0d5a1621fea252541cf67533c4b9c32ee892d790768f4ad48f1063059537"
+dependencies = [
+ "mocktopus_macros",
+]
+
+[[package]]
+name = "mocktopus_macros"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3048ef3680533a27f9f8e7d6a0bce44dc61e4895ea0f42709337fa1c8616fefe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5369,6 +5390,23 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "orml-tokens-allowance"
+version = "1.0.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "mocktopus",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sha2 0.8.2",
+ "sp-core",
+ "sp-io",
  "sp-runtime",
  "sp-std",
 ]

--- a/pallets/orml-tokens-allowance/Cargo.toml
+++ b/pallets/orml-tokens-allowance/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+authors = ["Pendulum Chain"]
+edition = "2021"
+name = "orml-tokens-allowance"
+version = "1.0.0"
+
+[dependencies]
+codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"]}
+scale-info = {version = "2.2.0", default-features = false, features = ["derive"]}
+serde = {version = "1.0.130", default-features = false, features = ["derive"], optional = true}
+sha2 = {version = "0.8.2", default-features = false}
+
+# Substrate dependencies
+frame-support = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
+frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
+sp-core = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
+sp-runtime = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
+sp-std = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
+
+
+
+[dev-dependencies]
+mocktopus = "0.8.0"
+sp-io = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
+
+[features]
+default = ["std"]
+std = [
+  "serde",
+  "codec/std",
+  "sha2/std",
+  "sp-core/std",
+  "sp-std/std",
+  "sp-runtime/std",
+  "frame-support/std",
+  "frame-system/std",
+]

--- a/pallets/orml-tokens-allowance/Cargo.toml
+++ b/pallets/orml-tokens-allowance/Cargo.toml
@@ -17,7 +17,7 @@ sp-core = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 sp-runtime = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
 sp-std = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
 
-
+orml-tokens = {git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.37" }
 
 [dev-dependencies]
 mocktopus = "0.8.0"
@@ -34,4 +34,5 @@ std = [
   "sp-runtime/std",
   "frame-support/std",
   "frame-system/std",
+  "orml-tokens/std"
 ]

--- a/pallets/orml-tokens-allowance/src/lib.rs
+++ b/pallets/orml-tokens-allowance/src/lib.rs
@@ -62,23 +62,36 @@ pub mod pallet {
 		T::Balance,
 	>;
 
+	#[pallet::storage]
+	/// Currencies that can be used to give approval
+	pub(super) type AllowedCurrencies<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		T::CurrencyId,
+		bool,
+	>;
+
 	#[pallet::hooks]
 	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
 
 	#[pallet::genesis_config]
-	pub struct GenesisConfig {
+	pub struct GenesisConfig<T : Config> {
+		pub allowed_currencies : Vec<T::CurrencyId>
 	}
 
 	#[cfg(feature = "std")]
-	impl Default for GenesisConfig {
+	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self {
-			Self {  }
+			Self { allowed_currencies : vec![] }
 		}
 	}
 
 	#[pallet::genesis_build]
-	impl<T: Config> GenesisBuild<T> for GenesisConfig {
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
+			for i in &self.allowed_currencies.clone(){
+				AllowedCurrencies::<T>::insert(i, true);
+			}
 		}
 	}
 

--- a/pallets/orml-tokens-allowance/src/lib.rs
+++ b/pallets/orml-tokens-allowance/src/lib.rs
@@ -49,6 +49,19 @@ pub mod pallet {
 		ParachainNotRunning,
 	}
 
+	#[pallet::storage]
+	/// Approved balance transfers. Balance is the amount approved for transfer.
+	/// First key is the asset ID, second key is the owner and third key is the delegate.
+	pub(super) type Approvals<T: Config> = StorageNMap<
+		_,
+		(
+			NMapKey<Blake2_128Concat, T::CurrencyId>,
+			NMapKey<Blake2_128Concat, T::AccountId>, // owner
+			NMapKey<Blake2_128Concat, T::AccountId>, // delegate
+		),
+		T::Balance,
+	>;
+
 	#[pallet::hooks]
 	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
 

--- a/pallets/orml-tokens-allowance/src/lib.rs
+++ b/pallets/orml-tokens-allowance/src/lib.rs
@@ -1,0 +1,83 @@
+
+// #![deny(warnings)]
+#![cfg_attr(test, feature(proc_macro_hygiene))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(test)]
+extern crate mocktopus;
+
+use codec::Encode;
+use frame_support::{
+	dispatch::{DispatchError, DispatchResult},
+	transactional,
+};
+#[cfg(test)]
+use mocktopus::macros::mockable;
+use sha2::{Digest, Sha256};
+use sp_core::{H256, U256};
+use sp_runtime::{traits::*, ArithmeticError};
+use sp_std::{collections::btree_set::BTreeSet, convert::TryInto, prelude::*, vec};
+
+// pub use pallet::*;
+
+
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	use super::*;
+
+	/// ## Configuration
+	/// The pallet's configuration trait.
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The overarching event type.
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		// RecoverFromErrors { new_status: StatusCode, cleared_errors: Vec<ErrorCode> },
+		UpdateActiveBlock { block_number: T::BlockNumber },
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// Parachain is not running.
+		ParachainNotRunning,
+	}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig {
+	}
+
+	#[cfg(feature = "std")]
+	impl Default for GenesisConfig {
+		fn default() -> Self {
+			Self {  }
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig {
+		fn build(&self) {
+		}
+	}
+
+	#[pallet::pallet]
+	#[pallet::without_storage_info]
+	pub struct Pallet<T>(_);
+
+	// The pallet's dispatchable functions.
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		
+	}
+}

--- a/pallets/orml-tokens-allowance/src/lib.rs
+++ b/pallets/orml-tokens-allowance/src/lib.rs
@@ -31,11 +31,9 @@ pub mod pallet {
 	/// ## Configuration
 	/// The pallet's configuration trait.
 	#[pallet::config]
-	pub trait Config: frame_system::Config {
+	pub trait Config: frame_system::Config + orml_tokens::Config {
 		/// The overarching event type.
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
-		
 	}
 
 	#[pallet::event]

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -75,6 +75,7 @@ orml-tokens = {git = "https://github.com/open-web3-stack/open-runtime-module-lib
 
 # KILT
 parachain-staking = {path = "../../pallets/parachain-staking", default-features = false}
+orml-tokens-allowance = {path = "../../pallets/orml-tokens-allowance", default-features = false}
 
 # DIA
 dia-oracle = {git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.37"}


### PR DESCRIPTION
Add new pallet (extension) for orml-tokens
- implement 2 methods that will replace pallet-assets
- new pallet has a name `orml-tokens-allowance`
- 1 `StorageNMap` -> allowance storage (owner, delegator, amount)
- 2 methods: -> do_approve_transfer(approve ERC20 fn) and do_transfer_approved (transfer_from ERC20 fn)