### PR TITLE
Use allowed currencies in chain ext for foucoco

### DIFF
--- a/pallets/orml-currencies-allowance-ext/src/lib.rs
+++ b/pallets/orml-currencies-allowance-ext/src/lib.rs
@@ -81,7 +81,7 @@ pub mod pallet {
 	/// Currencies that can be used in chain extension
 	#[pallet::storage]
 	pub(super) type AllowedCurrencies<T: Config> =
-		StorageMap<_, Blake2_128Concat, CurrencyOf<T>, bool>;
+		StorageMap<_, Blake2_128Concat, CurrencyOf<T>, ()>;
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
@@ -102,7 +102,7 @@ pub mod pallet {
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
 			for i in &self.allowed_currencies.clone() {
-				AllowedCurrencies::<T>::insert(i, true);
+				AllowedCurrencies::<T>::insert(i, ());
 			}
 		}
 	}
@@ -127,7 +127,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			ensure_root(origin)?;
 			for i in currencies.clone() {
-				AllowedCurrencies::<T>::insert(i, true);
+				AllowedCurrencies::<T>::insert(i, ());
 			}
 
 			Self::deposit_event(Event::AddedAllowedCurrencies { currencies });
@@ -178,7 +178,7 @@ impl<T: Config> Pallet<T> {
 		delegate: &T::AccountId,
 		amount: BalanceOf<T>,
 	) -> DispatchResult {
-		ensure!(AllowedCurrencies::<T>::get(id) == Some(true), Error::<T>::CurrencyNotLive);
+		ensure!(AllowedCurrencies::<T>::get(id) == Some(()), Error::<T>::CurrencyNotLive);
 		Approvals::<T>::try_mutate((id, &owner, &delegate), |maybe_approved| -> DispatchResult {
 			let mut approved = match maybe_approved.take() {
 				// an approval already exists and is being updated
@@ -215,7 +215,7 @@ impl<T: Config> Pallet<T> {
 		destination: &T::AccountId,
 		amount: BalanceOf<T>,
 	) -> DispatchResult {
-		ensure!(AllowedCurrencies::<T>::get(id) == Some(true), Error::<T>::CurrencyNotLive);
+		ensure!(AllowedCurrencies::<T>::get(id) == Some(()), Error::<T>::CurrencyNotLive);
 		Approvals::<T>::try_mutate_exists(
 			(id, &owner, delegate),
 			|maybe_approved| -> DispatchResult {

--- a/pallets/orml-currencies-allowance-ext/src/lib.rs
+++ b/pallets/orml-currencies-allowance-ext/src/lib.rs
@@ -160,6 +160,11 @@ pub mod pallet {
 #[cfg_attr(test, mockable)]
 impl<T: Config> Pallet<T> {
 	// Check the amount approved to be spent by an owner to a delegate
+	pub fn is_allowed_currency(asset: CurrencyOf<T>) -> bool {
+		return AllowedCurrencies::<T>::get(asset) == Some(())
+	}
+
+	// Check the amount approved to be spent by an owner to a delegate
 	pub fn allowance(
 		asset: CurrencyOf<T>,
 		owner: &T::AccountId,

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1138,6 +1138,15 @@ where
 				error!("balance : {:#?}", balance);
 
 				let currency_id = try_from(type_id, code, issuer).unwrap_or(CurrencyId::Native);
+
+				let is_allowed_currency =
+					orml_currencies_allowance_ext::Pallet::<T>::is_allowed_currency(currency_id);
+				if !is_allowed_currency {
+					return Err(DispatchError::Other(
+						"Currency id is not allowed for chain extension",
+					))
+				}
+
 				let result = <orml_currencies::Pallet<T> as MultiCurrency<T::AccountId>>::transfer(
 					currency_id,
 					&address_account,
@@ -1155,6 +1164,15 @@ where
 				let (type_id, code, issuer, account_id) = create_asset;
 
 				let currency_id = try_from(type_id, code, issuer).unwrap_or(CurrencyId::Native);
+
+				let is_allowed_currency =
+					orml_currencies_allowance_ext::Pallet::<T>::is_allowed_currency(currency_id);
+				if !is_allowed_currency {
+					return Err(DispatchError::Other(
+						"Currency id is not allowed for chain extension",
+					))
+				}
+
 				let balance =
 					<orml_currencies::Pallet<T> as MultiCurrency<T::AccountId>>::free_balance(
 						currency_id,
@@ -1176,6 +1194,14 @@ where
 				let (type_id, code, issuer, _account_id) = create_asset;
 
 				let currency_id = try_from(type_id, code, issuer).unwrap_or(CurrencyId::Native);
+
+				let is_allowed_currency =
+					orml_currencies_allowance_ext::Pallet::<T>::is_allowed_currency(currency_id);
+				if !is_allowed_currency {
+					return Err(DispatchError::Other(
+						"Currency id is not allowed for chain extension",
+					))
+				}
 
 				let total_supply =
 					<orml_currencies::Pallet<T> as MultiCurrency<T::AccountId>>::total_issuance(
@@ -1218,6 +1244,14 @@ where
 				error!("amount : {:#?}", amount);
 
 				let currency_id = try_from(type_id, code, issuer).unwrap_or(CurrencyId::Native);
+
+				let is_allowed_currency =
+					orml_currencies_allowance_ext::Pallet::<T>::is_allowed_currency(currency_id);
+				if !is_allowed_currency {
+					return Err(DispatchError::Other(
+						"Currency id is not allowed for chain extension",
+					))
+				}
 
 				let result = orml_currencies_allowance_ext::Pallet::<T>::do_approve_transfer(
 					currency_id,
@@ -1268,6 +1302,14 @@ where
 
 				let currency_id = try_from(type_id, code, issuer).unwrap_or(CurrencyId::Native);
 
+				let is_allowed_currency =
+					orml_currencies_allowance_ext::Pallet::<T>::is_allowed_currency(currency_id);
+				if !is_allowed_currency {
+					return Err(DispatchError::Other(
+						"Currency id is not allowed for chain extension",
+					))
+				}
+
 				let result = orml_currencies_allowance_ext::Pallet::<T>::do_transfer_approved(
 					currency_id,
 					&owner,
@@ -1300,6 +1342,14 @@ where
 				let currency_id =
 					try_from(allowance_request.0, allowance_request.1, allowance_request.2)
 						.unwrap_or(CurrencyId::Native);
+
+				let is_allowed_currency =
+					orml_currencies_allowance_ext::Pallet::<T>::is_allowed_currency(currency_id);
+				if !is_allowed_currency {
+					return Err(DispatchError::Other(
+						"Currency id is not allowed for chain extension",
+					))
+				}
 
 				let allowance = orml_currencies_allowance_ext::Pallet::<T>::allowance(
 					currency_id,


### PR DESCRIPTION
- use orml_currencies_allowance_ext::Pallet::<T>::is_allowed_currency(currency_id) fn to check currency id in chain extension for foucoco runtime.
- If not allowed than error will return from chain ext. Not allowed currency id