### PR TITLE
enable off chain workers for pendulum node.

### DIFF
--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -315,6 +315,15 @@ where
 			warp_sync: None,
 		})?;
 
+	if parachain_config.offchain_worker.enabled {
+		sc_service::build_offchain_workers(
+			&parachain_config,
+			task_manager.spawn_handle(),
+			client.clone(),
+			network.clone(),
+		);
+	}
+
 	let rpc_builder = {
 		let client = client.clone();
 		let transaction_pool = transaction_pool.clone();


### PR DESCRIPTION
- enable off chain workers for pendulum node.
- need redeploy the node. runtime upgrade will not fix issue with workers.