### PR TITLE
enable off chain workers for pendulum node.

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -27,14 +27,8 @@ jobs:
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Install toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly-2022-08-08
-        components: rustfmt, clippy
-        target: wasm32-unknown-unknown
-        override: true
-        default: true
+      # Call `rustup show` as a hack so that the toolchain defined in rust-toolchain.toml is installed
+      run: rustup show
 
     # Enable this for clippy linting.
     # - name: Check and Lint Code

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -40,6 +40,11 @@ jobs:
     # - name: Check and Lint Code
     #   run: cargo +nightly-2021-12-01 clippy -- -D warnings
 
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Check Code
       run: cargo check
 

--- a/README.md
+++ b/README.md
@@ -131,4 +131,4 @@ For local testing, you can replace `--name` with predefined keys like `--alice` 
 where `ALICE_NODE_ID` is the peer id of Alice.
 You can find the rococo-custom-2-raw.json [here](https://github.com/substrate-developer-hub/substrate-docs/blob/314e9cd3bd0ca9426bbfd381b79c3ef4d06b49c2/static/assets/tutorials/cumulus/chain-specs/rococo-custom-2-raw.json).
 
-There are prerequisites in running the collator with a local relay chain. Refer to [how to run Pendulum locally](https://pendulum.gitbook.io/pendulum-docs/build/running-pendulum-locally).
+There are prerequisites in running the collator with a local relay chain. Refer to [how to run Pendulum locally](https://pendulum.gitbook.io/pendulum-docs/build/build-environment/local-pendulum-chain-setup).

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -315,6 +315,15 @@ where
 			warp_sync: None,
 		})?;
 
+	if parachain_config.offchain_worker.enabled {
+		sc_service::build_offchain_workers(
+			&parachain_config,
+			task_manager.spawn_handle(),
+			client.clone(),
+			network.clone(),
+		);
+	}
+
 	let rpc_builder = {
 		let client = client.clone();
 		let transaction_pool = transaction_pool.clone();

--- a/runtime/foucoco/src/zenlink.rs
+++ b/runtime/foucoco/src/zenlink.rs
@@ -7,7 +7,7 @@ use sp_runtime::{DispatchError, DispatchResult};
 use sp_std::marker::PhantomData;
 
 use zenlink_protocol::{
-	AssetId, AssetIdConverter, Config as ZenlinkConfig, LocalAssetHandler, PairLpGenerate,
+	AssetId, AssetIdConverter, LocalAssetHandler, PairLpGenerate,
 	ZenlinkMultiAssets, LOCAL, NATIVE,
 };
 pub type ZenlinkAssetId = zenlink_protocol::AssetId;


### PR DESCRIPTION
- enable off-chain workers for pendulum node.
- need redeploy the node. runtime upgrade will not fix issue with workers.