### PR TITLE
Add chain ext to foucoco runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9404,9 +9404,12 @@ dependencies = [
 name = "runtime-common"
 version = "0.1.0"
 dependencies = [
+ "parity-scale-codec",
+ "scale-info",
  "sp-consensus-aura",
  "sp-core",
  "sp-runtime",
+ "spacewalk-primitives",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,6 +2807,7 @@ dependencies = [
  "nomination",
  "oracle",
  "orml-currencies",
+ "orml-currencies-allowance-ext",
  "orml-tokens 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
  "orml-traits 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
  "orml-xtokens",
@@ -5124,6 +5125,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "mocktopus"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4f0d5a1621fea252541cf67533c4b9c32ee892d790768f4ad48f1063059537"
+dependencies = [
+ "mocktopus_macros",
+]
+
+[[package]]
+name = "mocktopus_macros"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3048ef3680533a27f9f8e7d6a0bce44dc61e4895ea0f42709337fa1c8616fefe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "module-issue-rpc"
 version = "1.2.0"
 source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
@@ -5729,6 +5750,26 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "orml-currencies-allowance-ext"
+version = "1.0.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "mocktopus",
+ "orml-currencies",
+ "orml-tokens 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
+ "orml-traits 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sha2 0.8.2",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6031a462f977dd38968b6f23378356512feeace69cef817e1a4475108093cec3"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
 ]
@@ -1883,12 +1883,14 @@ dependencies = [
 [[package]]
 name = "currency"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "frame-support",
  "frame-system",
+ "orml-currencies",
  "orml-tokens 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
  "orml-traits 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
+ "pallet-balances",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
@@ -1984,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1994,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
@@ -2008,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
  "quote",
@@ -2627,12 +2629,13 @@ dependencies = [
 [[package]]
 name = "fee"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "currency",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "pallet-balances",
  "parity-scale-codec",
  "reward",
  "scale-info",
@@ -3620,9 +3623,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3896,7 +3899,7 @@ dependencies = [
 [[package]]
 name = "issue"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -3906,8 +3909,10 @@ dependencies = [
  "frame-system",
  "log",
  "oracle",
+ "orml-currencies",
  "orml-tokens 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
  "orml-traits 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
+ "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -5147,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "module-issue-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "jsonrpsee",
  "module-issue-rpc-runtime-api",
@@ -5160,7 +5165,7 @@ dependencies = [
 [[package]]
 name = "module-issue-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5171,7 +5176,7 @@ dependencies = [
 [[package]]
 name = "module-oracle-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5183,7 +5188,7 @@ dependencies = [
 [[package]]
 name = "module-redeem-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "jsonrpsee",
  "module-redeem-rpc-runtime-api",
@@ -5196,7 +5201,7 @@ dependencies = [
 [[package]]
 name = "module-redeem-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5207,7 +5212,7 @@ dependencies = [
 [[package]]
 name = "module-replace-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "jsonrpsee",
  "module-replace-rpc-runtime-api",
@@ -5220,7 +5225,7 @@ dependencies = [
 [[package]]
 name = "module-replace-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5231,7 +5236,7 @@ dependencies = [
 [[package]]
 name = "module-vault-registry-rpc"
 version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5245,7 +5250,7 @@ dependencies = [
 [[package]]
 name = "module-vault-registry-rpc-runtime-api"
 version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "frame-support",
  "module-oracle-rpc-runtime-api",
@@ -5506,7 +5511,7 @@ dependencies = [
 [[package]]
 name = "nomination"
 version = "0.5.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "currency",
  "fee",
@@ -5514,8 +5519,10 @@ dependencies = [
  "frame-support",
  "frame-system",
  "oracle",
+ "orml-currencies",
  "orml-tokens 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
  "orml-traits 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
+ "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
  "reward",
@@ -5676,7 +5683,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "oracle"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "currency",
  "dia-oracle",
@@ -5684,6 +5691,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "orml-oracle",
+ "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -9068,7 +9076,7 @@ dependencies = [
 [[package]]
 name = "redeem"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "currency",
  "fee",
@@ -9076,8 +9084,10 @@ dependencies = [
  "frame-support",
  "frame-system",
  "oracle",
+ "orml-currencies",
  "orml-tokens 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
  "orml-traits 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
+ "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -9188,7 +9198,7 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 [[package]]
 name = "replace"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "currency",
  "fee",
@@ -9197,8 +9207,10 @@ dependencies = [
  "frame-system",
  "nomination",
  "oracle",
+ "orml-currencies",
  "orml-tokens 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
  "orml-traits 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
+ "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -9228,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reward"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10802,7 +10814,7 @@ dependencies = [
 [[package]]
 name = "security"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11841,7 +11853,7 @@ dependencies = [
 [[package]]
 name = "spacewalk-primitives"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "bstringify",
  "frame-support",
@@ -11900,7 +11912,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staking"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11993,7 +12005,7 @@ dependencies = [
 [[package]]
 name = "stellar-relay"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -12948,7 +12960,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 [[package]]
 name = "vault-registry"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#c6d3ede8d9554e048157186c318b544bba6614d4"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=dev/milestone-3#d5c5b77109e1ef7ae4a2e9b7a654fb6ed7b7a32d"
 dependencies = [
  "currency",
  "fee",
@@ -12958,8 +12970,10 @@ dependencies = [
  "frame-system",
  "log",
  "oracle",
+ "orml-currencies",
  "orml-tokens 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
  "orml-traits 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",
+ "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
  "reward",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ members = [
 	"runtime/pendulum",
 	"runtime/development",
 ]
+
+exclude = [
+    "contracts/",
+]

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,12 @@
+cargo install cargo-contract --version 1.5.0
+
+Contracts
+
+If you have cargo-contract (https://github.com/paritytech/cargo-contract) installed, you can easily build with:
+
+`cargo contract build`
+
+For more info on writing and building ink smart contracts, see: https://github.com/paritytech/ink
+
+To deploy and use: https://contracts-ui.substrate.io/?rpc=ws://127.0.0.1:9944
+

--- a/contracts/psp_pendulum/.gitignore
+++ b/contracts/psp_pendulum/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/contracts/psp_pendulum/Cargo.lock
+++ b/contracts/psp_pendulum/Cargo.lock
@@ -46,17 +46,6 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
@@ -74,69 +63,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "brush"
-version = "1.6.0"
-source = "git+https://github.com/Supercolony-net/openbrush-contracts?branch=feature/psp22-extension-pallet-assets#84ec9fe1511d63b113f44d62ecfd2c08faad0ac4"
-dependencies = [
- "brush_lang",
- "contracts",
-]
-
-[[package]]
-name = "brush_derive"
-version = "1.6.0"
-source = "git+https://github.com/Supercolony-net/openbrush-contracts?branch=feature/psp22-extension-pallet-assets#84ec9fe1511d63b113f44d62ecfd2c08faad0ac4"
-
-[[package]]
-name = "brush_lang"
-version = "1.6.0"
-source = "git+https://github.com/Supercolony-net/openbrush-contracts?branch=feature/psp22-extension-pallet-assets#84ec9fe1511d63b113f44d62ecfd2c08faad0ac4"
-dependencies = [
- "ink_env",
- "ink_lang",
- "ink_primitives",
- "ink_storage",
- "proc_macros",
- "test_utils",
-]
-
-[[package]]
 name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
-
-[[package]]
-name = "camino"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6031a462f977dd38968b6f23378356512feeace69cef817e1a4475108093cec3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "semver-parser",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "cc"
@@ -149,23 +79,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "contracts"
-version = "1.6.0"
-source = "git+https://github.com/Supercolony-net/openbrush-contracts?branch=feature/psp22-extension-pallet-assets#84ec9fe1511d63b113f44d62ecfd2c08faad0ac4"
-dependencies = [
- "brush_lang",
- "derive",
- "ink_env",
- "ink_lang",
- "ink_metadata",
- "ink_prelude",
- "ink_primitives",
- "ink_storage",
- "parity-scale-codec",
- "scale-info",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -190,27 +103,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "derive"
-version = "1.6.0"
-source = "git+https://github.com/Supercolony-net/openbrush-contracts?branch=feature/psp22-extension-pallet-assets#84ec9fe1511d63b113f44d62ecfd2c08faad0ac4"
-dependencies = [
- "brush_derive",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -266,16 +158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba69ba11ab069d2f946bb46a199630ad6680fa3ecdc87a62c7477f9916095841"
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,15 +189,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -366,7 +239,7 @@ name = "ink_engine"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/ink?tag=v3.0.0#159e7db1560daed0136bb7dddfc07d40a06ca98d"
 dependencies = [
- "blake2 0.10.6",
+ "blake2",
  "derive_more",
  "parity-scale-codec",
  "rand",
@@ -381,7 +254,7 @@ version = "3.0.0"
 source = "git+https://github.com/paritytech/ink?tag=v3.0.0#159e7db1560daed0136bb7dddfc07d40a06ca98d"
 dependencies = [
  "arrayref",
- "blake2 0.10.6",
+ "blake2",
  "cfg-if",
  "derive_more",
  "ink_allocator",
@@ -431,10 +304,10 @@ name = "ink_lang_codegen"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/ink?tag=v3.0.0#159e7db1560daed0136bb7dddfc07d40a06ca98d"
 dependencies = [
- "blake2 0.10.6",
+ "blake2",
  "derive_more",
  "either",
- "heck 0.4.1",
+ "heck",
  "impl-serde",
  "ink_lang_ir",
  "itertools",
@@ -449,7 +322,7 @@ name = "ink_lang_ir"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/ink?tag=v3.0.0#159e7db1560daed0136bb7dddfc07d40a06ca98d"
 dependencies = [
- "blake2 0.10.6",
+ "blake2",
  "either",
  "itertools",
  "proc-macro2",
@@ -540,12 +413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
-
-[[package]]
 name = "keccak"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,12 +494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "parity-scale-codec"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,16 +526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
-name = "pest"
-version = "2.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
-dependencies = [
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,29 +551,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc_macros"
-version = "1.6.0"
-source = "git+https://github.com/Supercolony-net/openbrush-contracts?branch=feature/psp22-extension-pallet-assets#84ec9fe1511d63b113f44d62ecfd2c08faad0ac4"
-dependencies = [
- "blake2 0.9.2",
- "cargo_metadata",
- "fs2",
- "heck 0.3.3",
- "ink_lang_ir",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn",
- "synstructure",
- "unwrap",
-]
-
-[[package]]
 name = "psp22_pendulum"
 version = "1.6.0"
 dependencies = [
- "brush",
  "ethnum",
  "ink_env",
  "ink_lang",
@@ -786,12 +617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 
 [[package]]
-name = "ryu"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
 name = "scale-info"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,25 +661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,17 +678,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -948,36 +743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "test_utils"
-version = "0.1.0"
-source = "git+https://github.com/Supercolony-net/openbrush-contracts?branch=feature/psp22-extension-pallet-assets#84ec9fe1511d63b113f44d62ecfd2c08faad0ac4"
-dependencies = [
- "ink_env",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,34 +766,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775c11906edafc97bc378816b94585fbd9a054eabaf86fdd0ced94af449efab7"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "unwrap"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e33648dd74328e622c7be51f3b40a303c63f93e6fa5f08778b6203a4c25c20f"
 
 [[package]]
 name = "version_check"
@@ -1041,28 +788,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winnow"

--- a/contracts/psp_pendulum/Cargo.toml
+++ b/contracts/psp_pendulum/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "psp22_pendulum"
+version = "1.6.0"
+authors = ["pendulum-chain"]
+edition = "2021"
+
+[dependencies]
+ink_primitives = { tag = "v3.0.0", git = "https://github.com/paritytech/ink", default-features = false }
+ink_metadata = { tag = "v3.0.0", git = "https://github.com/paritytech/ink", default-features = false, features = ["derive"], optional = true }
+ink_env = { tag = "v3.0.0", git = "https://github.com/paritytech/ink", default-features = false }
+ink_storage = { tag = "v3.0.0", git = "https://github.com/paritytech/ink", default-features = false }
+ink_lang = { tag = "v3.0.0", git = "https://github.com/paritytech/ink", default-features = false }
+ink_prelude = { tag = "v3.0.0", git = "https://github.com/paritytech/ink", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+# sp_core = {version = "1" }
+# ethnum = { version = "1", features = ["llvm-intrinsics"] }
+ethnum = { version = "1", features = ["macros"] }
+
+# These dependencies
+# brush = { git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22"], branch = "feature/psp22-extension-pallet-assets" }
+
+[lib]
+name = "psp22_pendulum"
+path = "lib.rs"
+crate-type = [
+    # Used for normal contract Wasm blobs.
+    "cdylib",
+]
+
+[features]
+default = ["std"]
+std = [
+    "ink_primitives/std",
+    "ink_metadata",
+    "ink_metadata/std",
+    "ink_env/std",
+    "ink_storage/std",
+    "ink_lang/std",
+    "scale/std",
+    "scale-info",
+    "scale-info/std",
+
+    # These dependencies
+    # "brush/std",
+]
+ink-as-dependency = []
+
+[profile.dev]
+codegen-units = 16

--- a/contracts/psp_pendulum/lib.rs
+++ b/contracts/psp_pendulum/lib.rs
@@ -1,0 +1,304 @@
+// Copyright (c) 2012-2022 Supercolony
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the"Software"),
+// to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#![cfg_attr(not(feature = "std"), no_std)]
+#![feature(min_specialization)]
+
+use ethnum::U256;
+use ink_env::Environment;
+use ink_lang as ink;
+use ink_prelude::{string::String, vec::Vec};
+
+mod psp_pendulum_lib;
+
+// use crate::pallet_assets::*;
+// use brush::{
+// 	contracts::psp22::{utils::*, PSP22Error, *},
+// 	modifiers,
+// };
+use crate::psp_pendulum_lib::PSP22Error;
+use ink_lang::ChainExtensionInstance;
+
+// #[brush::contract]
+#[ink::contract]
+mod my_psp22_pallet_asset {
+	use crate::*;
+	// use brush::contracts::{
+	// 	psp22::{psp22_pallet_asset::*, *},
+	// 	traits::psp22::psp22asset::*,
+	// };
+	use ink_lang::codegen::StaticEnv;
+	use ink_prelude::string::String;
+	use ink_storage::traits::SpreadAllocate;
+
+	#[ink(storage)]
+	#[derive(Default, SpreadAllocate)]
+	pub struct MyPSP22 {
+		pub asset_id: (u8, [u8; 12], [u8; 32]),
+		pub origin_type: u8,
+	}
+
+	impl MyPSP22 {
+		#[ink(constructor)]
+		pub fn new(
+			origin_type: psp_pendulum_lib::OriginType,
+			asset_id: (u8, [u8; 12], [u8; 32]),
+		) -> Self {
+			ink_lang::codegen::initialize_contract(|instance: &mut MyPSP22| {
+				instance.origin_type =
+					if origin_type == psp_pendulum_lib::OriginType::Caller { 0 } else { 1 };
+				instance.asset_id = asset_id;
+			})
+		}
+
+		#[ink(message)]
+		pub fn get_address(&self) -> [u8; 32] {
+			let caller = self.env().caller();
+			*caller.as_ref()
+		}
+
+		#[ink(message, selector = 0x70a08231)]
+		pub fn balance(&self, account: AccountId) -> [u128; 2] {
+			let b = self._balance_of(account);
+			use ethnum::U256;
+			let balance_u256: U256 = U256::try_from(b).unwrap();
+			balance_u256.0
+		}
+
+		#[ink(message, selector = 0x23b872dd)]
+		pub fn transfer_from(&mut self, from: AccountId, to: AccountId, amount: [u128; 2]) {
+			use ethnum::U256;
+			let amount: u128 = U256(amount).try_into().unwrap();
+			self._transfer_from(from, to, amount, Vec::<u8>::new())
+				.expect("should transfer from");
+		}
+
+		#[ink(message, selector = 0xa9059cbb)]
+		pub fn transfer(&mut self, to: AccountId, amount: [u128; 2]) {
+			use ethnum::U256;
+			let amount: u128 = U256(amount).try_into().unwrap();
+			self._transfer(to, amount, Vec::<u8>::new()).expect("should transfer");
+		}
+	}
+
+	impl MyPSP22 {
+		fn _balance_of(&self, owner: AccountId) -> Balance {
+			psp_pendulum_lib::PendulumChainExt::balance(self.asset_id, *owner.as_ref()).unwrap()
+		}
+
+		fn _allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
+			psp_pendulum_lib::PendulumChainExt::allowance(
+				self.asset_id,
+				*owner.as_ref(),
+				*spender.as_ref(),
+			)
+			.unwrap()
+		}
+
+		fn _transfer(
+			&mut self,
+			to: AccountId,
+			value: Balance,
+			data: Vec<u8>,
+		) -> Result<(), PSP22Error> {
+			let origin: psp_pendulum_lib::OriginType = self.origin_type.into();
+			let result = psp_pendulum_lib::PendulumChainExt::transfer(
+				origin,
+				self.asset_id,
+				*to.as_ref(),
+				value.into(),
+			);
+			match result {
+				Result::<(), psp_pendulum_lib::PalletAssetErr>::Ok(_) =>
+					Result::<(), PSP22Error>::Ok(()),
+				Result::<(), psp_pendulum_lib::PalletAssetErr>::Err(e) =>
+					Result::<(), PSP22Error>::Err(PSP22Error::from(e)),
+			}
+		}
+
+		fn _transfer_from(
+			&mut self,
+			from: AccountId,
+			to: AccountId,
+			value: Balance,
+			data: Vec<u8>,
+		) -> Result<(), PSP22Error> {
+			let origin: psp_pendulum_lib::OriginType = self.origin_type.into();
+			let transfer_approved_result = psp_pendulum_lib::PendulumChainExt::transfer_approved(
+				origin,
+				self.asset_id,
+				*from.as_ref(),
+				*to.as_ref(),
+				value.into(),
+			);
+			match transfer_approved_result {
+				Result::<(), psp_pendulum_lib::PalletAssetErr>::Ok(_) =>
+					Result::<(), PSP22Error>::Ok(()),
+				Result::<(), psp_pendulum_lib::PalletAssetErr>::Err(e) =>
+					Result::<(), PSP22Error>::Err(PSP22Error::from(e)),
+			}
+		}
+
+		fn _approve(&mut self, spender: AccountId, value: Balance) -> Result<(), PSP22Error> {
+			let origin: psp_pendulum_lib::OriginType = self.origin_type.into();
+			let approve_transfer_result = psp_pendulum_lib::PendulumChainExt::approve_transfer(
+				origin,
+				self.asset_id,
+				*spender.as_ref(),
+				value.into(),
+			);
+			match approve_transfer_result {
+				Result::<(), psp_pendulum_lib::PalletAssetErr>::Ok(_) =>
+					Result::<(), PSP22Error>::Ok(()),
+				Result::<(), psp_pendulum_lib::PalletAssetErr>::Err(e) =>
+					Result::<(), PSP22Error>::Err(PSP22Error::from(e)),
+			}
+		}
+
+		fn _increase_allowance(
+			&mut self,
+			spender: AccountId,
+			delta_value: Balance,
+		) -> Result<(), PSP22Error> {
+			let owner = Self::env().caller();
+			let result = psp_pendulum_lib::PendulumChainExt::change_allowance(
+				self.asset_id,
+				*owner.as_ref(),
+				*spender.as_ref(),
+				delta_value,
+				true,
+			);
+
+			match result {
+				Result::<(), psp_pendulum_lib::PalletAssetErr>::Ok(_) =>
+					Result::<(), PSP22Error>::Ok(()),
+				Result::<(), psp_pendulum_lib::PalletAssetErr>::Err(e) =>
+					Result::<(), PSP22Error>::Err(PSP22Error::from(e)),
+			}
+		}
+
+		fn _decrease_allowance(
+			&mut self,
+			spender: AccountId,
+			delta_value: Balance,
+		) -> Result<(), PSP22Error> {
+			let owner = Self::env().caller();
+			let result = psp_pendulum_lib::PendulumChainExt::change_allowance(
+				self.asset_id,
+				*owner.as_ref(),
+				*spender.as_ref(),
+				delta_value,
+				false,
+			);
+
+			match result {
+				Result::<(), psp_pendulum_lib::PalletAssetErr>::Ok(_) =>
+					Result::<(), PSP22Error>::Ok(()),
+				Result::<(), psp_pendulum_lib::PalletAssetErr>::Err(e) =>
+					Result::<(), PSP22Error>::Err(PSP22Error::from(e)),
+			}
+		}
+	}
+
+	/// Unit tests in Rust are normally defined within such a `#[cfg(test)]`
+	#[cfg(test)]
+	mod tests {
+		/// Imports all the definitions from the outer scope so we can use them here.
+		use super::*;
+		use ink_lang as ink;
+
+		#[ink::test]
+		fn init_works() {
+			// given
+			struct CreateAssetExtension;
+			impl ink_env::test::ChainExtension for CreateAssetExtension {
+				/// The static function id of the chain extension.
+				fn func_id(&self) -> u32 {
+					1102
+				}
+
+				fn call(&mut self, _input: &[u8], output: &mut Vec<u8>) -> u32 {
+					let mut input = _input;
+					// let r :Result<PalletAssetRequest, scale::Error> = scale::Decode::decode(&mut input);
+					// assert!(r.is_err());
+
+					let create_result = Result::<(), psp_pendulum_lib::PalletAssetErr>::Ok(());
+					// let create_result = Result::<(), psp_pendulum_lib::PalletAssetErr>::Err(psp_pendulum_lib::PalletAssetErr::Other);
+					scale::Encode::encode_to(&create_result, output);
+					0
+				}
+			}
+			// arrange
+			ink_env::test::register_chain_extension(CreateAssetExtension);
+			// origin_type: psp_pendulum_lib::OriginType, asset_id: u32, target_address: [u8; 32], min_balance: u128
+			let mut my_psp22 = MyPSP22::new(psp_pendulum_lib::OriginType::Caller, 10, [1u8; 32], 1);
+			// assert
+			// assert_eq!(my_psp22.balance_pallet_asset(b.asset_id, b.address), 99);
+		}
+
+		// #[ink::test]
+		// fn chain_extension_balance_works() {
+		//     // given
+		//     struct MockedBalanceExtension;
+		//     impl ink_env::test::ChainExtension for MockedBalanceExtension {
+		//         /// The static function id of the chain extension.
+		//         fn func_id(&self) -> u32 {
+		//             1106
+		//         }
+
+		//         fn call(&mut self, _input: &[u8], output: &mut Vec<u8>) -> u32 {
+		//             let b: u128 = 99;
+		//             scale::Encode::encode_to(&b, output);
+		//             0
+		//         }
+		//     }
+		//     // arrange
+		//     ink_env::test::register_chain_extension(MockedBalanceExtension);
+		//     let mut my_psp22 = MyPSP22::new(100);
+		//     let b = PalletAssetBalanceRequest {
+		//         asset_id: 1,
+		//         address: [1; 32],
+		//     };
+		//     // assert
+		//     assert_eq!(my_psp22.balance_pallet_asset(b.asset_id, b.address), 99);
+		// }
+	}
+
+	// Here we define the operations to interact with the Substrate runtime.
+	// #[ink::chain_extension]
+	// pub trait PalletAssetExtension {
+	// type ErrorCode = psp_pendulum_lib::PalletAssetErr;
+	//
+	// #[ink(extension = 1102, returns_result = false)]
+	// fn create(subject: PalletAssetRequest) ->  Result<(), psp_pendulum_lib::PalletAssetErr>;
+	//
+	// #[ink(extension = 1103, returns_result = false)]
+	// fn mint(subject: PalletAssetRequest) ->  Result<(), psp_pendulum_lib::PalletAssetErr>;
+	//
+	// #[ink(extension = 1104, returns_result = false)]
+	// fn burn(subject: PalletAssetRequest) ->  Result<(), psp_pendulum_lib::PalletAssetErr>;
+	//
+	// #[ink(extension = 1105, returns_result = false)]
+	// fn transfer(subject: PalletAssetRequest) ->  Result<(), psp_pendulum_lib::PalletAssetErr>;
+	//
+	// #[ink(extension = 1106, returns_result = false)]
+	// fn balance(subject: PalletAssetBalanceRequest) ->  u128;
+	// }
+}

--- a/contracts/psp_pendulum/psp_pendulum_lib.rs
+++ b/contracts/psp_pendulum/psp_pendulum_lib.rs
@@ -1,0 +1,396 @@
+// Copyright (c) 2012-2022 Supercolony
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the"Software"),
+// to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/// Extension of [`PSP22`] which allows the beneficiary to extract tokens after given time
+use ink_env::Environment;
+use ink_lang as ink;
+use ink_prelude::{string::String, vec::Vec};
+
+// use crate::traits::psp22::PSP22Error;
+// use crate::PSP22Error;
+use ink_lang::ChainExtensionInstance;
+
+// use brush::{
+// 	declare_storage_trait,
+// 	traits::{AccountId, AccountIdExt, Balance, Flush},
+// };
+
+#[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum PSP22Error {
+    /// Custom error type for cases if writer of traits added own restrictions
+    Custom(String),
+    /// Returned if not enough balance to fulfill a request is available.
+    InsufficientBalance,
+    /// Returned if not enough allowance to fulfill a request is available.
+    InsufficientAllowance,
+    /// Returned if recipient's address is zero.
+    ZeroRecipientAddress,
+    /// Returned if sender's address is zero.
+    ZeroSenderAddress,
+    /// Returned if safe transfer check fails
+    SafeTransferCheckFailed(String),
+}
+
+pub struct PendulumChainExt;
+
+impl PendulumChainExt {
+	pub fn create(
+		origin_type: OriginType,
+		asset_id: (u8, [u8; 12], [u8; 32]),
+		target_address: [u8; 32],
+		min_balance: u128,
+	) -> Result<(), PalletAssetErr> {
+		let subject = PalletAssetRequest::new(origin_type, asset_id, target_address, min_balance);
+		::ink_env::chain_extension::ChainExtensionMethod::build(1102u32)
+			.input::<PalletAssetRequest>()
+			.output::<Result<(), PalletAssetErr>>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&subject)?
+	}
+
+	pub fn mint(
+		origin_type: OriginType,
+		asset_id: (u8, [u8; 12], [u8; 32]),
+		target_address: [u8; 32],
+		amount: u128,
+	) -> Result<(), PalletAssetErr> {
+		let subject = PalletAssetRequest::new(origin_type, asset_id, target_address, amount);
+		::ink_env::chain_extension::ChainExtensionMethod::build(1103u32)
+			.input::<PalletAssetRequest>()
+			.output::<Result<(), PalletAssetErr>>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&subject)?
+	}
+
+	pub fn burn(
+		origin_type: OriginType,
+		asset_id: (u8, [u8; 12], [u8; 32]),
+		target_address: [u8; 32],
+		amount: u128,
+	) -> Result<(), PalletAssetErr> {
+		let subject = PalletAssetRequest::new(origin_type, asset_id, target_address, amount);
+		::ink_env::chain_extension::ChainExtensionMethod::build(1104u32)
+			.input::<PalletAssetRequest>()
+			.output::<Result<(), PalletAssetErr>>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&subject)?
+	}
+
+	pub fn transfer(
+		origin_type: OriginType,
+		asset_id: (u8, [u8; 12], [u8; 32]),
+		target_address: [u8; 32],
+		amount: u128,
+	) -> Result<(), PalletAssetErr> {
+		let subject = PalletAssetRequest::new(origin_type, asset_id, target_address, amount);
+		::ink_env::chain_extension::ChainExtensionMethod::build(1105u32)
+			.input::<PalletAssetRequest>()
+			.output::<Result<(), PalletAssetErr>>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&subject)?
+	}
+
+	pub fn balance(
+		asset_id: (u8, [u8; 12], [u8; 32]),
+		address: [u8; 32],
+	) -> Result<u128, PalletAssetErr> {
+		let subject = PalletAssetBalanceRequest {
+			type_id: asset_id.0,
+			code: asset_id.1,
+			issuer: asset_id.2,
+			address,
+		};
+		::ink_env::chain_extension::ChainExtensionMethod::build(1106u32)
+			.input::<PalletAssetBalanceRequest>()
+			.output::<u128>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&subject)
+	}
+
+	pub fn total_supply(asset_id: (u8, [u8; 12], [u8; 32])) -> Result<u128, PalletAssetErr> {
+		::ink_env::chain_extension::ChainExtensionMethod::build(1107u32)
+			.input::<(u8, [u8; 12], [u8; 32])>()
+			.output::<u128>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&asset_id)
+	}
+
+	pub fn approve_transfer(
+		origin_type: OriginType,
+		asset_id: (u8, [u8; 12], [u8; 32]),
+		target_address: [u8; 32],
+		amount: u128,
+	) -> Result<(), PalletAssetErr> {
+		let subject = PalletAssetRequest::new(origin_type, asset_id, target_address, amount);
+		::ink_env::chain_extension::ChainExtensionMethod::build(1108u32)
+			.input::<PalletAssetRequest>()
+			.output::<Result<(), PalletAssetErr>>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&subject)?
+	}
+
+	pub fn transfer_approved(
+		origin_type: OriginType,
+		asset_id: (u8, [u8; 12], [u8; 32]),
+		owner: [u8; 32],
+		target_address: [u8; 32],
+		amount: u128,
+	) -> Result<(), PalletAssetErr> {
+		let subject = PalletAssetRequest::new(origin_type, asset_id, target_address, amount);
+		::ink_env::chain_extension::ChainExtensionMethod::build(1109u32)
+			.input::<([u8; 32], PalletAssetRequest)>()
+			.output::<Result<(), PalletAssetErr>>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&(owner, subject))?
+	}
+
+	pub fn allowance(
+		asset_id: (u8, [u8; 12], [u8; 32]),
+		owner: [u8; 32],
+		spender: [u8; 32],
+	) -> Result<u128, PalletAssetErr> {
+		::ink_env::chain_extension::ChainExtensionMethod::build(1110u32)
+			.input::<(u8, [u8; 12], [u8; 32], [u8; 32], [u8; 32])>()
+			.output::<u128>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&(asset_id.0, asset_id.1, asset_id.2, owner, spender))
+	}
+
+	// increase or decrease
+	pub fn change_allowance(
+		asset_id: (u8, [u8; 12], [u8; 32]),
+		owner: [u8; 32],
+		delegate: [u8; 32],
+		delta_value: u128,
+		is_increase: bool,
+	) -> Result<(), PalletAssetErr> {
+		::ink_env::chain_extension::ChainExtensionMethod::build(1111u32)
+			.input::<(u8, [u8; 12], [u8; 32], [u8; 32], [u8; 32], u128, bool)>()
+			.output::<Result<(), PalletAssetErr>>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&(
+				asset_id.0,
+				asset_id.1,
+				asset_id.2,
+				owner,
+				delegate,
+				delta_value,
+				is_increase,
+			))?
+	}
+
+	pub fn set_metadata(
+		origin_type: OriginType,
+		asset_id: (u8, [u8; 12], [u8; 32]),
+		name: Vec<u8>,
+		symbol: Vec<u8>,
+		decimals: u8,
+	) -> Result<(), PalletAssetErr> {
+		::ink_env::chain_extension::ChainExtensionMethod::build(1112u32)
+			.input::<(OriginType, u8, [u8; 12], [u8; 32], Vec<u8>, Vec<u8>, u8)>()
+			.output::<Result<(), PalletAssetErr>>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&(origin_type, asset_id.0, asset_id.1, asset_id.2, name, symbol, decimals))?
+	}
+
+	pub fn metadata_name(asset_id: (u8, [u8; 12], [u8; 32])) -> Result<Vec<u8>, PalletAssetErr> {
+		::ink_env::chain_extension::ChainExtensionMethod::build(1113u32)
+			.input::<(u8, [u8; 12], [u8; 32])>()
+			.output::<Vec<u8>>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&asset_id)
+	}
+
+	pub fn metadata_symbol(asset_id: (u8, [u8; 12], [u8; 32])) -> Result<Vec<u8>, PalletAssetErr> {
+		::ink_env::chain_extension::ChainExtensionMethod::build(1114u32)
+			.input::<(u8, [u8; 12], [u8; 32])>()
+			.output::<Vec<u8>>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&asset_id)
+	}
+
+	pub fn metadata_decimals(asset_id: (u8, [u8; 12], [u8; 32])) -> Result<u8, PalletAssetErr> {
+		::ink_env::chain_extension::ChainExtensionMethod::build(1115u32)
+			.input::<(u8, [u8; 12], [u8; 32])>()
+			.output::<u8>()
+			.handle_error_code::<PalletAssetErr>()
+			.call(&asset_id)
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum RequestType {
+	Create,
+	Mint,
+	Burn,
+	Transfer,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum OriginType {
+	Caller,
+	Address,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct PalletAssetRequest {
+	pub origin_type: OriginType,
+	pub type_id: u8,
+	pub code: [u8; 12],
+	pub issuer: [u8; 32],
+	pub target_address: [u8; 32],
+	pub amount: u128,
+}
+
+impl PalletAssetRequest {
+	fn new(
+		origin_type: OriginType,
+		asset_id: (u8, [u8; 12], [u8; 32]),
+		target_address: [u8; 32],
+		amount: u128,
+	) -> PalletAssetRequest {
+		PalletAssetRequest {
+			origin_type,
+			type_id: asset_id.0,
+			code: asset_id.1,
+			issuer: asset_id.2,
+			target_address,
+			amount,
+		}
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct PalletAssetBalanceRequest {
+	pub type_id: u8,
+	pub code: [u8; 12],
+	pub issuer: [u8; 32],
+	pub address: [u8; 32],
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum PalletAssetErr {
+	/// Some error occurred.
+	Other,
+	/// Failed to lookup some data.
+	CannotLookup,
+	/// A bad origin.
+	BadOrigin,
+	/// A custom error in a module.
+	Module,
+	/// At least one consumer is remaining so the account cannot be destroyed.
+	ConsumerRemaining,
+	/// There are no providers so the account cannot be created.
+	NoProviders,
+	/// There are too many consumers so the account cannot be created.
+	TooManyConsumers,
+	/// An error to do with tokens.
+	Token(PalletAssetTokenErr),
+	/// An arithmetic error.
+	Arithmetic(PalletAssetArithmeticErr),
+	// unknown error
+	Unknown,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum PalletAssetArithmeticErr {
+	/// Underflow.
+	Underflow,
+	/// Overflow.
+	Overflow,
+	/// Division by zero.
+	DivisionByZero,
+	// unknown error
+	Unknown,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum PalletAssetTokenErr {
+	/// Funds are unavailable.
+	NoFunds,
+	/// Account that must exist would die.
+	WouldDie,
+	/// Account cannot exist with the funds that would be given.
+	BelowMinimum,
+	/// Account cannot be created.
+	CannotCreate,
+	/// The asset in question is unknown.
+	UnknownAsset,
+	/// Funds exist but are frozen.
+	Frozen,
+	/// Operation is not supported by the asset.
+	Unsupported,
+	// unknown error
+	Unknown,
+}
+
+impl From<u8> for OriginType {
+	fn from(origin: u8) -> OriginType {
+		if origin == 0 {
+			OriginType::Caller
+		} else {
+			OriginType::Address
+		}
+	}
+}
+
+impl From<PalletAssetErr> for PSP22Error {
+	fn from(e: PalletAssetErr) -> PSP22Error {
+		match e {
+			PalletAssetErr::Other => PSP22Error::Custom(String::from("psp22 error")),
+			PalletAssetErr::CannotLookup => PSP22Error::Custom(String::from("CannotLookup")),
+			PalletAssetErr::BadOrigin => PSP22Error::Custom(String::from("BadOrigin")),
+			PalletAssetErr::Module => PSP22Error::Custom(String::from("Module")),
+			PalletAssetErr::ConsumerRemaining =>
+				PSP22Error::Custom(String::from("ConsumerRemaining")),
+			PalletAssetErr::NoProviders => PSP22Error::Custom(String::from("NoProviders")),
+			PalletAssetErr::TooManyConsumers =>
+				PSP22Error::Custom(String::from("TooManyConsumers")),
+			PalletAssetErr::Token(token_err) => PSP22Error::Custom(String::from("Token")),
+			PalletAssetErr::Arithmetic(arithmetic_error) =>
+				PSP22Error::Custom(String::from("Arithmetic")),
+			_ => PSP22Error::Custom(String::from("Unnown")),
+		}
+	}
+}
+
+impl ink_env::chain_extension::FromStatusCode for PalletAssetErr {
+	fn from_status_code(status_code: u32) -> Result<(), Self> {
+		match status_code {
+			0 => Ok(()),
+			_ => panic!("encountered unknown status code"),
+		}
+	}
+}
+
+impl From<scale::Error> for PalletAssetErr {
+	fn from(_: scale::Error) -> Self {
+		panic!("encountered unexpected invalid SCALE encoding")
+	}
+}

--- a/pallets/orml-currencies-allowance-ext/Cargo.toml
+++ b/pallets/orml-currencies-allowance-ext/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+authors = ["Pendulum Chain"]
+edition = "2021"
+name = "orml-currencies-allowance-ext"
+version = "1.0.0"
+
+[dependencies]
+codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"]}
+scale-info = {version = "2.2.0", default-features = false, features = ["derive"]}
+serde = {version = "1.0.130", default-features = false, features = ["derive"], optional = true}
+sha2 = {version = "0.8.2", default-features = false}
+
+# Substrate dependencies
+frame-support = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
+frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
+sp-core = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
+sp-runtime = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
+sp-std = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
+
+orml-tokens = {git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.37" }
+orml-currencies = {git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.37" }
+orml-traits = {git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.37" }
+
+[dev-dependencies]
+mocktopus = "0.8.0"
+sp-io = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false}
+
+[features]
+default = ["std"]
+std = [
+  "serde",
+  "codec/std",
+  "sha2/std",
+  "sp-core/std",
+  "sp-std/std",
+  "sp-runtime/std",
+  "frame-support/std",
+  "frame-system/std",
+  "orml-currencies/std",
+  "orml-tokens/std",
+  "orml-traits/std"
+]

--- a/pallets/orml-currencies-allowance-ext/src/lib.rs
+++ b/pallets/orml-currencies-allowance-ext/src/lib.rs
@@ -161,8 +161,7 @@ pub mod pallet {
 impl<T: Config> Pallet<T> {
 	// Check the amount approved to be spent by an owner to a delegate
 	pub fn is_allowed_currency(asset: CurrencyOf<T>) -> bool {
-		return true;
-		// return AllowedCurrencies::<T>::get(asset) == Some(())
+		return AllowedCurrencies::<T>::get(asset) == Some(())
 	}
 
 	// Check the amount approved to be spent by an owner to a delegate

--- a/pallets/orml-currencies-allowance-ext/src/lib.rs
+++ b/pallets/orml-currencies-allowance-ext/src/lib.rs
@@ -1,0 +1,249 @@
+// #![deny(warnings)]
+#![cfg_attr(test, feature(proc_macro_hygiene))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(test)]
+extern crate mocktopus;
+
+use frame_support::{dispatch::DispatchResult, ensure};
+#[cfg(test)]
+use mocktopus::macros::mockable;
+use orml_traits::MultiCurrency;
+use sp_runtime::traits::*;
+use sp_std::{convert::TryInto, prelude::*, vec};
+
+pub use pallet::*;
+
+pub(crate) type BalanceOf<T> =
+	<<T as orml_currencies::Config>::MultiCurrency as orml_traits::MultiCurrency<
+		<T as frame_system::Config>::AccountId,
+	>>::Balance;
+
+pub(crate) type CurrencyOf<T> =
+	<<T as orml_currencies::Config>::MultiCurrency as orml_traits::MultiCurrency<
+		<T as frame_system::Config>::AccountId,
+	>>::CurrencyId;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::{pallet_prelude::*, transactional};
+	use frame_system::{ensure_root, pallet_prelude::OriginFor};
+
+	use super::*;
+
+	/// ## Configuration
+	/// The pallet's configuration trait.
+	#[pallet::config]
+	pub trait Config: frame_system::Config + orml_tokens::Config + orml_currencies::Config {
+		/// The overarching event type.
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		AddedAllowedCurrencies {
+			currencies: Vec<CurrencyOf<T>>,
+		},
+		DeletedAllowedCurrencies {
+			currencies: Vec<CurrencyOf<T>>,
+		},
+		/// (Additional) funds have been approved for transfer to a destination account.
+		ApprovedTransfer {
+			currency_id: CurrencyOf<T>,
+			source: T::AccountId,
+			delegate: T::AccountId,
+			amount: BalanceOf<T>,
+		},
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// Parachain is not running.
+		Unapproved,
+		ParachainNotRunning,
+		CurrencyNotLive,
+	}
+
+	/// Approved balance transfers. Balance is the amount approved for transfer.
+	/// First key is the currency ID, second key is the owner and third key is the delegate.
+	#[pallet::storage]
+	pub type Approvals<T: Config> = StorageNMap<
+		_,
+		(
+			NMapKey<Blake2_128Concat, CurrencyOf<T>>,
+			NMapKey<Blake2_128Concat, T::AccountId>, // owner
+			NMapKey<Blake2_128Concat, T::AccountId>, // delegate
+		),
+		BalanceOf<T>,
+	>;
+
+	/// Currencies that can be used in chain extension
+	#[pallet::storage]
+	pub(super) type AllowedCurrencies<T: Config> =
+		StorageMap<_, Blake2_128Concat, CurrencyOf<T>, ()>;
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		pub allowed_currencies: Vec<CurrencyOf<T>>,
+	}
+
+	#[cfg(feature = "std")]
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			Self { allowed_currencies: vec![] }
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+		fn build(&self) {
+			for i in &self.allowed_currencies.clone() {
+				AllowedCurrencies::<T>::insert(i, ());
+			}
+		}
+	}
+
+	#[pallet::pallet]
+	#[pallet::without_storage_info]
+	pub struct Pallet<T>(_);
+
+	// The pallet's dispatchable functions.
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Added allowed currencies that possible to use chain extension
+		///
+		/// # Arguments
+		/// * `currencies` - list of currency id allowed to use in chain extension
+		#[pallet::call_index(1)]
+		#[pallet::weight(10000)]
+		#[transactional]
+		pub fn add_allowed_currencies(
+			origin: OriginFor<T>,
+			currencies: Vec<CurrencyOf<T>>,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+			for i in currencies.clone() {
+				AllowedCurrencies::<T>::insert(i, ());
+			}
+
+			Self::deposit_event(Event::AddedAllowedCurrencies { currencies });
+			Ok(())
+		}
+
+		/// Remove allowed currencies that possible to use chain extension
+		///
+		/// # Arguments
+		/// * `currencies` - list of currency id allowed to use in chain extension
+		#[pallet::call_index(2)]
+		#[pallet::weight(10000)]
+		#[transactional]
+		pub fn remove_allowed_currencies(
+			origin: OriginFor<T>,
+			currencies: Vec<CurrencyOf<T>>,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+			for i in currencies.clone() {
+				AllowedCurrencies::<T>::remove(i);
+			}
+
+			Self::deposit_event(Event::DeletedAllowedCurrencies { currencies });
+			Ok(())
+		}
+	}
+}
+
+#[allow(clippy::forget_non_drop, clippy::swap_ptr_to_ref, clippy::forget_ref, clippy::forget_copy)]
+#[cfg_attr(test, mockable)]
+impl<T: Config> Pallet<T> {
+	// Check the amount approved to be spent by an owner to a delegate
+	pub fn is_allowed_currency(asset: CurrencyOf<T>) -> bool {
+		return true;
+		// return AllowedCurrencies::<T>::get(asset) == Some(())
+	}
+
+	// Check the amount approved to be spent by an owner to a delegate
+	pub fn allowance(
+		asset: CurrencyOf<T>,
+		owner: &T::AccountId,
+		delegate: &T::AccountId,
+	) -> BalanceOf<T> {
+		Approvals::<T>::get((asset, &owner, &delegate)).unwrap_or_else(Zero::zero)
+	}
+
+	/// Creates an approval from `owner` to spend `amount` of asset `id` tokens by 'delegate'
+	/// while reserving `T::ApprovalDeposit` from owner
+	///
+	/// If an approval already exists, the new amount is added to such existing approval
+	pub fn do_approve_transfer(
+		id: CurrencyOf<T>,
+		owner: &T::AccountId,
+		delegate: &T::AccountId,
+		amount: BalanceOf<T>,
+	) -> DispatchResult {
+		ensure!(Self::is_allowed_currency(id), Error::<T>::CurrencyNotLive);
+		Approvals::<T>::try_mutate((id, &owner, &delegate), |maybe_approved| -> DispatchResult {
+			let mut approved = match maybe_approved.take() {
+				// an approval already exists and is being updated
+				Some(a) => a,
+				// a new approval is created
+				None => Default::default(),
+			};
+
+			approved = approved.saturating_add(amount);
+			*maybe_approved = Some(approved);
+			Ok(())
+		})?;
+		Self::deposit_event(Event::ApprovedTransfer {
+			currency_id: id,
+			source: owner.clone(),
+			delegate: delegate.clone(),
+			amount,
+		});
+
+		Ok(())
+	}
+
+	/// Reduces the asset `id` balance of `owner` by some `amount` and increases the balance of
+	/// `dest` by (similar) amount, checking that 'delegate' has an existing approval from `owner`
+	/// to spend`amount`.
+	///
+	/// Will fail if `amount` is greater than the approval from `owner` to 'delegate'
+	/// Will unreserve the deposit from `owner` if the entire approved `amount` is spent by
+	/// 'delegate'
+	pub fn do_transfer_approved(
+		id: CurrencyOf<T>,
+		owner: &T::AccountId,
+		delegate: &T::AccountId,
+		destination: &T::AccountId,
+		amount: BalanceOf<T>,
+	) -> DispatchResult {
+		ensure!(Self::is_allowed_currency(id), Error::<T>::CurrencyNotLive);
+		Approvals::<T>::try_mutate_exists(
+			(id, &owner, delegate),
+			|maybe_approved| -> DispatchResult {
+				let mut approved = maybe_approved.take().ok_or(Error::<T>::Unapproved)?;
+				let remaining = approved.checked_sub(&amount).ok_or(Error::<T>::Unapproved)?;
+
+				<orml_currencies::Pallet<T> as MultiCurrency<T::AccountId>>::transfer(
+					id,
+					&owner,
+					&destination,
+					amount,
+				)?;
+
+				if remaining.is_zero() {
+					*maybe_approved = None;
+				} else {
+					approved = remaining;
+					*maybe_approved = Some(approved);
+				}
+				Ok(())
+			},
+		)?;
+		Ok(())
+	}
+}

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -12,9 +12,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Substrate
+parity-scale-codec = {version = "3.1.5", default-features = false, features = ["derive"]}
+scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch = "dev/milestone-3" }
 
 [features]
 default = [
@@ -25,6 +28,9 @@ std = [
 	"sp-consensus-aura/std",
 	"sp-runtime/std",
 	"sp-core/std",
+	"spacewalk-primitives/std",
+	"parity-scale-codec/std",
+	"scale-info/std"
 ]
 
 runtime-benchmarks = [

--- a/runtime/common/src/chain_ext.rs
+++ b/runtime/common/src/chain_ext.rs
@@ -1,0 +1,158 @@
+use crate::*;
+use sp_core::{Decode, Encode, MaxEncodedLen};
+use sp_runtime::{ArithmeticError, TokenError};
+use spacewalk_primitives::{Asset, CurrencyId};
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
+pub enum OriginType {
+	Caller,
+	Address,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
+struct PalletAssetRequest {
+	origin_type: OriginType,
+	asset_id: u32,
+	target_address: [u8; 32],
+	amount: u128,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
+struct PalletAssetBalanceRequest {
+	asset_id: u32,
+	address: [u8; 32],
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
+pub enum ChainExtensionErr {
+	/// Some error occurred.
+	Other,
+	/// Failed to lookup some data.
+	CannotLookup,
+	/// A bad origin.
+	BadOrigin,
+	/// A custom error in a module.
+	Module,
+	/// At least one consumer is remaining so the account cannot be destroyed.
+	ConsumerRemaining,
+	/// There are no providers so the account cannot be created.
+	NoProviders,
+	/// There are too many consumers so the account cannot be created.
+	TooManyConsumers,
+	/// An error to do with tokens.
+	Token(PalletAssetTokenErr),
+	/// An arithmetic error.
+	Arithmetic(PalletAssetArithmeticErr),
+	/// Unknown error
+	Unknown,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
+pub enum PalletAssetArithmeticErr {
+	/// Underflow.
+	Underflow,
+	/// Overflow.
+	Overflow,
+	/// Division by zero.
+	DivisionByZero,
+	/// Unknown error
+	Unknown,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
+pub enum PalletAssetTokenErr {
+	/// Funds are unavailable.
+	NoFunds,
+	/// Account that must exist would die.
+	WouldDie,
+	/// Account cannot exist with the funds that would be given.
+	BelowMinimum,
+	/// Account cannot be created.
+	CannotCreate,
+	/// The asset in question is unknown.
+	UnknownAsset,
+	/// Funds exist but are frozen.
+	Frozen,
+	/// Operation is not supported by the asset.
+	Unsupported,
+	/// Unknown error
+	Unknown,
+}
+
+impl From<DispatchError> for ChainExtensionErr {
+	fn from(e: DispatchError) -> Self {
+		match e {
+			DispatchError::Other(_) => ChainExtensionErr::Other,
+			DispatchError::CannotLookup => ChainExtensionErr::CannotLookup,
+			DispatchError::BadOrigin => ChainExtensionErr::BadOrigin,
+			DispatchError::Module(_) => ChainExtensionErr::Module,
+			DispatchError::ConsumerRemaining => ChainExtensionErr::ConsumerRemaining,
+			DispatchError::NoProviders => ChainExtensionErr::NoProviders,
+			DispatchError::TooManyConsumers => ChainExtensionErr::TooManyConsumers,
+			DispatchError::Token(token_err) =>
+				ChainExtensionErr::Token(PalletAssetTokenErr::from(token_err)),
+			DispatchError::Arithmetic(arithmetic_error) =>
+				ChainExtensionErr::Arithmetic(PalletAssetArithmeticErr::from(arithmetic_error)),
+			_ => ChainExtensionErr::Unknown,
+		}
+	}
+}
+
+impl From<ArithmeticError> for PalletAssetArithmeticErr {
+	fn from(e: ArithmeticError) -> Self {
+		match e {
+			ArithmeticError::Underflow => PalletAssetArithmeticErr::Underflow,
+			ArithmeticError::Overflow => PalletAssetArithmeticErr::Overflow,
+			ArithmeticError::DivisionByZero => PalletAssetArithmeticErr::DivisionByZero,
+		}
+	}
+}
+
+impl From<TokenError> for PalletAssetTokenErr {
+	fn from(e: TokenError) -> Self {
+		match e {
+			TokenError::NoFunds => PalletAssetTokenErr::NoFunds,
+			TokenError::WouldDie => PalletAssetTokenErr::WouldDie,
+			TokenError::BelowMinimum => PalletAssetTokenErr::BelowMinimum,
+			TokenError::CannotCreate => PalletAssetTokenErr::CannotCreate,
+			TokenError::UnknownAsset => PalletAssetTokenErr::UnknownAsset,
+			TokenError::Frozen => PalletAssetTokenErr::Frozen,
+			TokenError::Unsupported => PalletAssetTokenErr::Unsupported,
+		}
+	}
+}
+
+pub fn try_from(type_id: u8, code: [u8; 12], issuer: [u8; 32]) -> Result<CurrencyId, ()> {
+	match type_id {
+		0 => {
+			let foreign_currency_id = code[0];
+			match foreign_currency_id {
+				0 => Ok(CurrencyId::XCM(0)),
+				1 => Ok(CurrencyId::XCM(1)),
+				2 => Ok(CurrencyId::XCM(2)),
+				3 => Ok(CurrencyId::XCM(3)),
+				4 => Ok(CurrencyId::XCM(4)),
+				5 => Ok(CurrencyId::XCM(5)),
+				6 => Ok(CurrencyId::XCM(6)),
+				7 => Ok(CurrencyId::XCM(7)),
+				8 => Ok(CurrencyId::XCM(8)),
+				9 => Ok(CurrencyId::XCM(9)),
+				10 => Ok(CurrencyId::XCM(10)),
+				11 => Ok(CurrencyId::XCM(11)),
+				12 => Ok(CurrencyId::XCM(12)),
+				13 => Ok(CurrencyId::XCM(13)),
+				14 => Ok(CurrencyId::XCM(14)),
+				15 => Ok(CurrencyId::XCM(15)),
+				16 => Ok(CurrencyId::XCM(16)),
+				_ => Err(()),
+			}
+		},
+		1 => Ok(CurrencyId::Native),
+		2 => Ok(CurrencyId::StellarNative),
+		3 => {
+			let code = [code[0], code[1], code[2], code[3]];
+			Ok(CurrencyId::Stellar(Asset::AlphaNum4 { code, issuer }))
+		},
+		4 => Ok(CurrencyId::Stellar(Asset::AlphaNum12 { code, issuer })),
+		_ => Err(()),
+	}
+}

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -2,8 +2,10 @@
 
 use sp_runtime::{
 	traits::{IdentifyAccount, Verify},
-	MultiSignature,
+	DispatchError, MultiSignature,
 };
+
+pub mod chain_ext;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -97,6 +97,8 @@ orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 # KILT
 parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
 
+orml-currencies-allowance-ext = {path = "../../pallets/orml-currencies-allowance-ext", default-features = false}
+
 # DIA
 dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.37" }
 dia-oracle-runtime-api = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.37" }
@@ -217,6 +219,7 @@ std = [
     "module-replace-rpc-runtime-api/std",
     "module-vault-registry-rpc-runtime-api/std",
     "spacewalk-primitives/std",
+    "orml-currencies-allowance-ext/std"
 ]
 
 runtime-benchmarks = [


### PR DESCRIPTION
- add `orml-currencies-allowance-ext` that add `ERC20` functionality to orml currencies (allowance, transfer_from, approve)
- add basic implementation and conversion to runtime-common
- add `chain extension` to **Foucoco** runtime to support ink! wrapper for any currency based on pendulum chain.
- `ink!` contract that represent the wrapper around any currency on top of pendulum using chain extension.


WARNING: By default there are no allowed currency that possible to use via wrapper.
To add currency to AllowedCurrencies StorageMap need to call extrinsic in `orml-currencies-allowance-ext` pallet -> `add_allowed_currencies`
