### PR TITLE
Use Stellar testnet on Foucoco

### DIFF
--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1066,7 +1066,7 @@ impl oracle::Config for Runtime {
 parameter_types! {
 	pub const OrganizationLimit: u32 = 255;
 	pub const ValidatorLimit: u32 = 255;
-	pub const IsPublicNetwork: bool = true;
+	pub const IsPublicNetwork: bool = false;
 }
 
 impl stellar_relay::Config for Runtime {


### PR DESCRIPTION
This should be enough to change the Stellar network to testnet. Setting the necessary parameters has to be done in a sudo transaction afterwards.

Closes #168.