### PR TITLE
Configure pendulum runtime for xcm simulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14357,6 +14357,7 @@ dependencies = [
  "frame-system",
  "pallet-balances",
  "pallet-xcm",
+ "parachain-info",
  "parity-scale-codec",
  "pendulum-runtime",
  "polkadot-core-primitives",

--- a/runtime/integration-tests/pendulum/Cargo.toml
+++ b/runtime/integration-tests/pendulum/Cargo.toml
@@ -16,6 +16,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.37" }
 
 xcm-simulator = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
 xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
@@ -28,5 +29,6 @@ polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = 
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
 polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
 polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
+
 
 pendulum-runtime = { path = "../../pendulum"}

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -14,6 +14,7 @@ use crate::zenlink::*;
 use xcm::v1::MultiLocation;
 use zenlink_protocol::{AssetBalance, MultiAssetsHandler, PairInfo};
 
+pub use currency::CurrencyId as PendulumCurrencyId;
 pub use parachain_staking::InflationInfo;
 
 use codec::Encode;

--- a/runtime/pendulum/src/xcm_config.rs
+++ b/runtime/pendulum/src/xcm_config.rs
@@ -7,7 +7,10 @@ use frame_support::{
 	log, match_types, parameter_types,
 	traits::{Everything, Nothing},
 };
-use orml_traits::{location::{RelativeReserveProvider, Reserve}, parameter_type_with_key};
+use orml_traits::{
+	location::{RelativeReserveProvider, Reserve},
+	parameter_type_with_key,
+};
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
@@ -16,12 +19,12 @@ use sp_runtime::traits::Convert;
 use xcm::latest::{prelude::*, Weight as XCMWeight};
 use xcm_builder::{
 	AccountId32Aliases, AllowUnpaidExecutionFrom, ConvertedConcreteAssetId, EnsureXcmOrigin,
-	FixedWeightBounds, FungiblesAdapter, LocationInverter, ParentIsPreset,
-	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
-	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, UsingComponents,
+	FixedWeightBounds, FungiblesAdapter, LocationInverter, ParentIsPreset, RelayChainAsNative,
+	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	SignedToAccountId32, SovereignSignedViaLocation, UsingComponents,
 };
 use xcm_executor::{
-	traits::{JustTry, ShouldExecute, FilterAssetLocation},
+	traits::{FilterAssetLocation, JustTry, ShouldExecute},
 	XcmExecutor,
 };
 
@@ -124,7 +127,7 @@ where
 	fn filter_asset_location(asset: &MultiAsset, origin: &MultiLocation) -> bool {
 		if let Some(ref reserve) = ReserveProvider::reserve(asset) {
 			if reserve == origin {
-				return true;
+				return true
 			}
 		}
 		false


### PR DESCRIPTION
- use parachain-info from cumulus repo to specify para id
- create `ExtBuilderPendulum` to return `TestExternalities` for `new_ext` in `decl_test_parachain!`
- use `default_parachains_host_configuration` to set up HostConfiguration for polkadot. (the same value as on production)
- expose `CurrencyId` as `PendulumCurrencyId` from pendulum-runtime package to use it in integration tests. 