### PR TITLE
Statemint integration tests to cover USDT bidirectional reserve transfer Pendulum <-> Statemint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14571,6 +14571,7 @@ name = "xcm-simulator-example"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-dmp-queue",
+ "cumulus-pallet-xcmp-queue",
  "frame-support",
  "frame-system",
  "orml-tokens 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.37)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6069,6 +6069,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-asset-tx-payment"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-assets"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
@@ -7011,6 +7044,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-uniques"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
@@ -7126,6 +7174,32 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-std",
+]
+
+[[package]]
+name = "parachains-common"
+version = "1.0.0"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.37#09418fc04c2608b123f36ca80f16df3d2096753b"
+dependencies = [
+ "cumulus-primitives-utility",
+ "frame-support",
+ "frame-system",
+ "pallet-asset-tx-payment",
+ "pallet-assets",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-collator-selection",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "scale-info",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "substrate-wasm-builder",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -12050,6 +12124,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "statemint-runtime"
+version = "1.0.0"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.37#09418fc04c2608b123f36ca80f16df3d2096753b"
+dependencies = [
+ "cumulus-pallet-aura-ext",
+ "cumulus-pallet-dmp-queue",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-session-benchmarking",
+ "cumulus-pallet-xcm",
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-core",
+ "cumulus-primitives-timestamp",
+ "cumulus-primitives-utility",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-rpc-runtime-api",
+ "log",
+ "pallet-asset-tx-payment",
+ "pallet-assets",
+ "pallet-aura",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-collator-selection",
+ "pallet-multisig",
+ "pallet-proxy",
+ "pallet-session",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-uniques",
+ "pallet-utility",
+ "pallet-xcm",
+ "parachain-info",
+ "parachains-common",
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
+ "polkadot-runtime-common",
+ "polkadot-runtime-constants",
+ "scale-info",
+ "smallvec",
+ "sp-api",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-inherents",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-std",
+ "sp-transaction-pool",
+ "sp-version",
+ "substrate-wasm-builder",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14457,6 +14591,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "statemint-runtime",
  "xcm",
  "xcm-builder",
  "xcm-emulator",

--- a/runtime/integration-tests/pendulum/Cargo.toml
+++ b/runtime/integration-tests/pendulum/Cargo.toml
@@ -36,3 +36,5 @@ orml-tokens = {git = "https://github.com/open-web3-stack/open-runtime-module-lib
 cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.37"}
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.37" }
 pendulum-runtime = { path = "../../pendulum"}
+
+statemint-runtime = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.37" }

--- a/runtime/integration-tests/pendulum/Cargo.toml
+++ b/runtime/integration-tests/pendulum/Cargo.toml
@@ -38,3 +38,5 @@ orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-l
 pendulum-runtime = { path = "../../pendulum"}
 
 statemint-runtime = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.37" }
+
+cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.37"}

--- a/runtime/integration-tests/pendulum/src/lib.rs
+++ b/runtime/integration-tests/pendulum/src/lib.rs
@@ -43,6 +43,16 @@ decl_test_parachain! {
 	}
 }
 
+// decl_test_parachain! {
+// 	pub struct Statemine {
+// 		Runtime = statemine_runtime::Runtime,
+// 		RuntimeOrigin = statemine_runtime::RuntimeOrigin,
+// 		XcmpMessageHandler = statemine_runtime::XcmpQueue,
+// 		DmpMessageHandler = statemine_runtime::DmpQueue,
+// 		new_ext = para_ext(1000),
+// 	}
+// }
+
 decl_test_network! {
 	pub struct MockNet {
 		relay_chain = Relay,
@@ -328,3 +338,5 @@ fn transfer_polkadot_from_pendulum_to_relay_chain() {
 		assert_eq!(after_bob_free_balance, dot(100) + transfer_dot_amount - FEE);
 	});
 }
+
+

--- a/runtime/integration-tests/pendulum/src/lib.rs
+++ b/runtime/integration-tests/pendulum/src/lib.rs
@@ -472,5 +472,14 @@ fn statemine_transfer_asset_to_pendulum() {
 			r.event,
 			RuntimeEvent::XcmpQueue(cumulus_pallet_xcmp_queue::Event::Success { .. })
 		)));
+
+		assert_eq!(
+			pendulum_runtime::Tokens::balance(
+				pendulum_runtime::PendulumCurrencyId::XCM(1),
+				&BOB.into()
+			),
+			TEN
+		);
+
 	});
 }


### PR DESCRIPTION
PR related to issue https://github.com/pendulum-chain/pendulum/issues/174
- add dependency of statemint-runtime from [parity cumulus](https://github.com/paritytech/cumulus).
- configure statemint runtime for MockNet.
- register asset with id 1984 to simulate USDT as sufficient on system parachain.
- cover bidirectional transfer from Statemint to Pendulum and back.
- unit test to check `transfer DOT from pendulum to relay chain`