### PR TITLE
add the oracle rpc in the node, foucoco runtime, and amplitude runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5229,6 +5229,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "module-oracle-rpc"
+version = "1.2.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+dependencies = [
+ "jsonrpsee",
+ "module-oracle-rpc-runtime-api",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
 name = "module-oracle-rpc-runtime-api"
 version = "1.2.0"
 source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
@@ -7271,6 +7284,7 @@ dependencies = [
  "jsonrpsee",
  "log",
  "module-issue-rpc",
+ "module-oracle-rpc",
  "module-redeem-rpc",
  "module-replace-rpc",
  "module-vault-registry-rpc",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 
 module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
+module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
 module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
 module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
 module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -103,10 +103,12 @@ where
 		H256,
 		RedeemRequest<AccountId, BlockNumber, Balance, CurrencyId>,
 	>,
+	C::Api: module_oracle_rpc::OracleRuntimeApi<Block, Balance, CurrencyId>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + Sync + Send + 'static,
 {
 	use module_issue_rpc::{Issue, IssueApiServer};
+	use module_oracle_rpc::{Oracle, OracleApiServer};
 	use module_redeem_rpc::{Redeem, RedeemApiServer};
 	use module_replace_rpc::{Replace, ReplaceApiServer};
 	use module_vault_registry_rpc::{VaultRegistry, VaultRegistryApiServer};
@@ -121,7 +123,8 @@ where
 	module.merge(Issue::new(client.clone()).into_rpc())?;
 	module.merge(Redeem::new(client.clone()).into_rpc())?;
 	module.merge(Replace::new(client.clone()).into_rpc())?;
-	module.merge(VaultRegistry::new(client).into_rpc())?;
+	module.merge(VaultRegistry::new(client.clone()).into_rpc())?;
+	module.merge(Oracle::new(client).into_rpc())?;
 
 	Ok(module)
 }

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1659,6 +1659,18 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl module_oracle_rpc_runtime_api::OracleApi<Block, Balance, CurrencyId> for Runtime {
+		fn currency_to_usd(amount:BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+			let result = Oracle::currency_to_usd(amount.amount, currency_id)?;
+			Ok(BalanceWrapper{amount:result})
+		}
+
+		fn usd_to_currency(amount:BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+			let result = Oracle::usd_to_currency(amount.amount, currency_id)?;
+			Ok(BalanceWrapper{amount:result})
+		}
+	}
+
 }
 
 struct CheckInherents;

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -2080,6 +2080,18 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl module_oracle_rpc_runtime_api::OracleApi<Block, Balance, CurrencyId> for Runtime {
+		fn currency_to_usd(amount:BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+			let result = Oracle::currency_to_usd(amount.amount, currency_id)?;
+			Ok(BalanceWrapper{amount:result})
+		}
+
+		fn usd_to_currency(amount:BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+			let result = Oracle::usd_to_currency(amount.amount, currency_id)?;
+			Ok(BalanceWrapper{amount:result})
+		}
+	}
+
 }
 
 struct CheckInherents;


### PR DESCRIPTION
Closes #185.

* Updated the node.rs to include `module_oracle_rpc` for spacewalk.
* Updated the runtime of foucoco and amplitude to include `module_oracle_rpc_runtime_api`