### PR TITLE
make Foucoco xcm config identical to pendulum runtime

### DIFF
--- a/runtime/foucoco/src/xcm_config.rs
+++ b/runtime/foucoco/src/xcm_config.rs
@@ -7,7 +7,10 @@ use frame_support::{
 	log, match_types, parameter_types,
 	traits::{Everything, Nothing},
 };
-use orml_traits::{location::AbsoluteReserveProvider, parameter_type_with_key};
+use orml_traits::{
+	location::{RelativeReserveProvider, Reserve},
+	parameter_type_with_key,
+};
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
@@ -15,12 +18,12 @@ use sp_runtime::traits::Convert;
 use xcm::latest::{prelude::*, Weight as XCMWeight};
 use xcm_builder::{
 	AccountId32Aliases, AllowUnpaidExecutionFrom, ConvertedConcreteAssetId, EnsureXcmOrigin,
-	FixedWeightBounds, FungiblesAdapter, LocationInverter, NativeAsset, ParentIsPreset,
-	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
-	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, UsingComponents,
+	FixedWeightBounds, FungiblesAdapter, LocationInverter, ParentIsPreset, RelayChainAsNative,
+	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	SignedToAccountId32, SovereignSignedViaLocation, UsingComponents,
 };
 use xcm_executor::{
-	traits::{JustTry, ShouldExecute},
+	traits::{FilterAssetLocation, JustTry, ShouldExecute},
 	XcmExecutor,
 };
 
@@ -91,6 +94,23 @@ impl xcm_executor::traits::Convert<MultiLocation, CurrencyId> for CurrencyIdConv
 			return Ok(CurrencyId::XCM(0))
 		}
 		Err(location.clone())
+	}
+}
+
+/// A `FilterAssetLocation` implementation. Filters multi native assets whose
+/// reserve is same with `origin`.
+pub struct MultiNativeAsset<ReserveProvider>(PhantomData<ReserveProvider>);
+impl<ReserveProvider> FilterAssetLocation for MultiNativeAsset<ReserveProvider>
+where
+	ReserveProvider: Reserve,
+{
+	fn filter_asset_location(asset: &MultiAsset, origin: &MultiLocation) -> bool {
+		if let Some(ref reserve) = ReserveProvider::reserve(asset) {
+			if reserve == origin {
+				return true
+			}
+		}
+		false
 	}
 }
 
@@ -220,7 +240,7 @@ impl xcm_executor::Config for XcmConfig {
 	// How to withdraw and deposit an asset.
 	type AssetTransactor = FungiblesTransactor;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	type IsReserve = NativeAsset;
+	type IsReserve = MultiNativeAsset<RelativeReserveProvider>;
 	type IsTeleporter = (); // Teleporting is disabled.
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Barrier = Barrier;
@@ -286,7 +306,7 @@ impl orml_xtokens::Config for Runtime {
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
 	type MinXcmFee = ParachainMinFee; //TODO to support hrmp transfer beetween parachain adjust this parameter
 	type MultiLocationsFilter = Everything;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = RelativeReserveProvider;
 }
 
 pub struct AccountIdToMultiLocation;

--- a/runtime/integration-tests/pendulum/src/tests.rs
+++ b/runtime/integration-tests/pendulum/src/tests.rs
@@ -36,7 +36,9 @@ fn transfer_dot_from_relay_chain_to_pendulum() {
 		assert_ok!(polkadot_runtime::XcmPallet::reserve_transfer_assets(
 			polkadot_runtime::RuntimeOrigin::signed(ALICE.into()),
 			Box::new(X1(Parachain(2094)).into().into()),
-			Box::new(X1(Junction::AccountId32 { network: NetworkId::Any, id: ALICE }).into().into()),
+			Box::new(
+				X1(Junction::AccountId32 { network: NetworkId::Any, id: ALICE }).into().into()
+			),
 			Box::new((Here, transfer_amount).into()),
 			0
 		));


### PR DESCRIPTION
Use the same xcm configuration for foucoco as for pendulum xcm config runtime.
It will help us to be sure that it will works correct once we deployed to Foucoco.