### PR TITLE
204 update spacewalk dependencies to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "currency"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2718,7 +2718,7 @@ dependencies = [
 [[package]]
 name = "fee"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -3989,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "issue"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -5255,7 +5255,7 @@ dependencies = [
 [[package]]
 name = "module-issue-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "jsonrpsee",
  "module-issue-rpc-runtime-api",
@@ -5268,7 +5268,7 @@ dependencies = [
 [[package]]
 name = "module-issue-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5279,7 +5279,7 @@ dependencies = [
 [[package]]
 name = "module-oracle-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5292,7 +5292,7 @@ dependencies = [
 [[package]]
 name = "module-oracle-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5304,7 +5304,7 @@ dependencies = [
 [[package]]
 name = "module-redeem-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "jsonrpsee",
  "module-redeem-rpc-runtime-api",
@@ -5317,7 +5317,7 @@ dependencies = [
 [[package]]
 name = "module-redeem-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5328,7 +5328,7 @@ dependencies = [
 [[package]]
 name = "module-replace-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "jsonrpsee",
  "module-replace-rpc-runtime-api",
@@ -5341,7 +5341,7 @@ dependencies = [
 [[package]]
 name = "module-replace-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5352,7 +5352,7 @@ dependencies = [
 [[package]]
 name = "module-vault-registry-rpc"
 version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5366,7 +5366,7 @@ dependencies = [
 [[package]]
 name = "module-vault-registry-rpc-runtime-api"
 version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "frame-support",
  "module-oracle-rpc-runtime-api",
@@ -5628,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "nomination"
 version = "0.5.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "currency",
  "fee",
@@ -5800,7 +5800,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "oracle"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "currency",
  "dia-oracle",
@@ -9273,7 +9273,7 @@ dependencies = [
 [[package]]
 name = "redeem"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "currency",
  "fee",
@@ -9404,7 +9404,7 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 [[package]]
 name = "replace"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "currency",
  "fee",
@@ -9446,7 +9446,7 @@ dependencies = [
 [[package]]
 name = "reward"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11054,7 +11054,7 @@ dependencies = [
 [[package]]
 name = "security"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12093,7 +12093,7 @@ dependencies = [
 [[package]]
 name = "spacewalk-primitives"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "base58",
  "bstringify",
@@ -12153,7 +12153,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staking"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12306,7 +12306,7 @@ dependencies = [
 [[package]]
 name = "stellar-relay"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -13278,7 +13278,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 [[package]]
 name = "vault-registry"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=5183e8730a3a10492d0be80720f68e236e0dee10#5183e8730a3a10492d0be80720f68e236e0dee10"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=c4bdbb8f5ce74023e06898ef7576d1ce93882ac1#c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"
 dependencies = [
  "currency",
  "fee",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,13 +15,13 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.145", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 
-module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
+module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
 
 # Local
 amplitude-runtime = {path = "../runtime/amplitude"}

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -13,7 +13,7 @@ use sp_runtime::{
 	traits::{IdentifyAccount, Verify},
 	FixedPointNumber, FixedU128, Perquintill,
 };
-use spacewalk_primitives::{oracle::Key, CurrencyId, CurrencyId::XCM, VaultCurrencyPair};
+use spacewalk_primitives::{oracle::Key, Asset, CurrencyId, CurrencyId::XCM, VaultCurrencyPair};
 
 use crate::constants::pendulum;
 
@@ -60,13 +60,13 @@ const INITIAL_AMPLITUDE_VALIDATORS: [&str; 8] = [
 ];
 
 // For mainnet USDC issued by centre.io
-const MAINNET_DEFAULT_WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4 {
+const MAINNET_DEFAULT_WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::Stellar(Asset::AlphaNum4 {
 	code: *b"USDC",
 	issuer: [
 		59, 153, 17, 56, 14, 254, 152, 139, 160, 168, 144, 14, 177, 207, 228, 79, 54, 111, 125,
 		190, 148, 107, 237, 7, 114, 64, 247, 246, 36, 223, 21, 197,
 	],
-};
+});
 
 // For Testnet USDC issued by the testnet issuer
 const TESTNET_DEFAULT_WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4(

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -59,6 +59,24 @@ const INITIAL_AMPLITUDE_VALIDATORS: [&str; 8] = [
 	"6jq7obxC7AxhWeJNzopwYidKNNe48cLrbGSgB2zs2SuRTWGA",
 ];
 
+// For mainnet USDC issued by centre.io
+const MAINNET_DEFAULT_WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4 {
+	code: *b"USDC",
+	issuer: [
+		59, 153, 17, 56, 14, 254, 152, 139, 160, 168, 144, 14, 177, 207, 228, 79, 54, 111, 125,
+		190, 148, 107, 237, 7, 114, 64, 247, 246, 36, 223, 21, 197,
+	],
+};
+
+// For Testnet USDC issued by the testnet issuer
+const TESTNET_DEFAULT_WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4(
+	*b"USDC",
+	[
+		20, 209, 150, 49, 176, 55, 23, 217, 171, 154, 54, 110, 16, 50, 30, 226, 102, 231, 46, 199,
+		108, 171, 97, 144, 240, 161, 51, 109, 72, 34, 159, 139,
+	],
+);
+
 const FOUCOCO_PARACHAIN_ID: u32 = 2124;
 
 /// Helper function to generate a crypto pair from seed
@@ -494,10 +512,7 @@ fn amplitude_genesis(
 	start_shutdown: bool,
 ) -> amplitude_runtime::GenesisConfig {
 	fn default_pair(currency_id: CurrencyId) -> VaultCurrencyPair<CurrencyId> {
-		VaultCurrencyPair {
-			collateral: currency_id,
-			wrapped: amplitude_runtime::DefaultWrappedCurrencyId::get(),
-		}
+		VaultCurrencyPair { collateral: currency_id, wrapped: MAINNET_DEFAULT_WRAPPED_CURRENCY_ID }
 	}
 
 	let mut balances: Vec<_> = signatories
@@ -614,7 +629,7 @@ fn amplitude_genesis(
 			max_delay: u32::MAX,
 			oracle_keys: vec![
 				Key::ExchangeRate(CurrencyId::XCM(0)),
-				Key::ExchangeRate(amplitude_runtime::DefaultWrappedCurrencyId::get()),
+				Key::ExchangeRate(MAINNET_DEFAULT_WRAPPED_CURRENCY_ID),
 			],
 		},
 		vault_registry: amplitude_runtime::VaultRegistryConfig {
@@ -671,10 +686,7 @@ fn foucoco_genesis(
 	start_shutdown: bool,
 ) -> foucoco_runtime::GenesisConfig {
 	fn default_pair(currency_id: CurrencyId) -> VaultCurrencyPair<CurrencyId> {
-		VaultCurrencyPair {
-			collateral: currency_id,
-			wrapped: foucoco_runtime::DefaultWrappedCurrencyId::get(),
-		}
+		VaultCurrencyPair { collateral: currency_id, wrapped: TESTNET_DEFAULT_WRAPPED_CURRENCY_ID }
 	}
 
 	let mut balances: Vec<_> = signatories
@@ -795,7 +807,7 @@ fn foucoco_genesis(
 			max_delay: u32::MAX,
 			oracle_keys: vec![
 				Key::ExchangeRate(CurrencyId::XCM(0)),
-				Key::ExchangeRate(foucoco_runtime::WRAPPED_USDC_CURRENCY),
+				Key::ExchangeRate(TESTNET_DEFAULT_WRAPPED_CURRENCY_ID),
 			],
 		},
 		vault_registry: foucoco_runtime::VaultRegistryConfig {

--- a/runtime/amplitude/Cargo.toml
+++ b/runtime/amplitude/Cargo.toml
@@ -26,24 +26,24 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # Custom libraries for Spacewalk
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10" }
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1" }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.37" }

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1548,7 +1548,7 @@ impl_runtime_apis! {
 			VaultRegistry::get_collateralization_from_vault_and_collateral(vault, &amount, only_issued)
 		}
 		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, wrapped_currency_id: CurrencyId, collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-			let amount_wrapped = currency::Amount::new(amount_wrapped.amount(), wrapped_currency_id);
+			let amount_wrapped = currency::Amount::new(amount_wrapped.amount, wrapped_currency_id);
 			let result = VaultRegistry::get_required_collateral_for_wrapped(&amount_wrapped, collateral_currency_id)?;
 			Ok(BalanceWrapper{amount:result.amount()})
 		}

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -276,15 +276,6 @@ const MAXIMUM_BLOCK_WEIGHT: Weight =
 	Weight::from_ref_time(WEIGHT_REF_TIME_PER_SECOND.saturating_div(2))
 		.set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);
 
-// For mainnet USDC issued by centre.io
-pub const WRAPPED_USDC_CURRENCY: CurrencyId = CurrencyId::AlphaNum4(
-	*b"USDC",
-	[
-		59, 153, 17, 56, 14, 254, 152, 139, 160, 168, 144, 14, 177, 207, 228, 79, 54, 111, 125,
-		190, 148, 107, 237, 7, 114, 64, 247, 246, 36, 223, 21, 197,
-	],
-);
-
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
 pub fn native_version() -> NativeVersion {
@@ -818,7 +809,6 @@ impl orml_tokens::Config for Runtime {
 
 parameter_types! {
 	pub const NativeCurrencyId: CurrencyId = CurrencyId::Native;
-	pub const DefaultWrappedCurrencyId: CurrencyId = WRAPPED_USDC_CURRENCY;
 }
 
 impl orml_currencies::Config for Runtime {
@@ -1557,9 +1547,9 @@ impl_runtime_apis! {
 			let amount = currency::Amount::new(collateral.amount, vault.collateral_currency());
 			VaultRegistry::get_collateralization_from_vault_and_collateral(vault, &amount, only_issued)
 		}
-		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-			let amount_wrapped = currency::Amount::new(amount_wrapped.amount, DefaultWrappedCurrencyId::get());
-			let result = VaultRegistry::get_required_collateral_for_wrapped(&amount_wrapped, currency_id)?;
+		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, wrapped_currency_id: CurrencyId, collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+			let amount_wrapped = currency::Amount::new(amount_wrapped.amount(), wrapped_currency_id);
+			let result = VaultRegistry::get_required_collateral_for_wrapped(&amount_wrapped, collateral_currency_id)?;
 			Ok(BalanceWrapper{amount:result.amount()})
 		}
 		fn get_required_collateral_for_vault(vault_id: VaultId) -> Result<BalanceWrapper<Balance>, DispatchError> {

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -17,7 +17,7 @@ scale-info = {version = "2.1.1", default-features = false, features = ["derive"]
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
 
 [features]
 default = [

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -26,25 +26,25 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # custom libraries from spacewalk
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
 
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "5183e8730a3a10492d0be80720f68e236e0dee10"}
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "c4bdbb8f5ce74023e06898ef7576d1ce93882ac1"}
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.37" }

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -282,15 +282,6 @@ const MAXIMUM_BLOCK_WEIGHT: Weight =
 	Weight::from_ref_time(WEIGHT_REF_TIME_PER_SECOND.saturating_div(2))
 		.set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);
 
-// For mainnet USDC issued by centre.io
-pub const WRAPPED_USDC_CURRENCY: CurrencyId = CurrencyId::AlphaNum4(
-	*b"USDC",
-	[
-		59, 153, 17, 56, 14, 254, 152, 139, 160, 168, 144, 14, 177, 207, 228, 79, 54, 111, 125,
-		190, 148, 107, 237, 7, 114, 64, 247, 246, 36, 223, 21, 197,
-	],
-);
-
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
 pub fn native_version() -> NativeVersion {
@@ -819,7 +810,6 @@ impl orml_tokens::Config for Runtime {
 
 parameter_types! {
 	pub const NativeCurrencyId: CurrencyId = CurrencyId::Native;
-	pub const DefaultWrappedCurrencyId: CurrencyId = WRAPPED_USDC_CURRENCY;
 }
 
 impl orml_currencies::Config for Runtime {
@@ -1973,9 +1963,9 @@ impl_runtime_apis! {
 			VaultRegistry::get_collateralization_from_vault_and_collateral(vault, &amount, only_issued)
 		}
 
-		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-			let amount_wrapped = currency::Amount::new(amount_wrapped.amount, DefaultWrappedCurrencyId::get());
-			let result = VaultRegistry::get_required_collateral_for_wrapped(&amount_wrapped, currency_id)?;
+		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, wrapped_currency_id: CurrencyId, collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+			let amount_wrapped = currency::Amount::new(amount_wrapped.amount, wrapped_currency_id);
+			let result = VaultRegistry::get_required_collateral_for_wrapped(&amount_wrapped, collateral_currency_id)?;
 			Ok(BalanceWrapper{amount:result.amount()})
 		}
 


### PR DESCRIPTION
We changed the signature of one of the RPC methods to not rely on a default wrapped currency anymore. Thus, this variable was now removed from the runtimes. I moved it to the `chain_spec.rs` instead so that we can use it in the genesis configurations though.

Closes #204.