### PR TITLE
bump foucoco spec version to perform runtime upgrade

### DIFF
--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -244,10 +244,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("amplitude"),
 	impl_name: create_runtime_str!("amplitude"),
 	authoring_version: 1,
-	spec_version: 9,
+	spec_version: 10,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 20,
+	transaction_version: 21,
 	state_version: 1,
 };
 


### PR DESCRIPTION
PR related to https://github.com/pendulum-chain/pendulum/issues/205
- bump spec version to perform runtime upgrade on Foucoco chain.