### PR TITLE
Add farming rpc api intou pendulum node for foucoco runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "bifrost-farming-rpc-api"
+version = "0.8.0"
+source = "git+https://github.com/pendulum-chain/bifrost?branch=introduce-abstraction-for-currency-id#a7778200b6aca64819391241936f4849f785e2d6"
+dependencies = [
+ "bifrost-farming-rpc-runtime-api",
+ "jsonrpsee",
+ "node-primitives",
+ "parity-scale-codec",
+ "serde",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-rpc",
+ "sp-runtime",
+]
+
+[[package]]
 name = "bifrost-farming-rpc-runtime-api"
 version = "0.8.0"
 source = "git+https://github.com/pendulum-chain/bifrost?branch=introduce-abstraction-for-currency-id#a7778200b6aca64819391241936f4849f785e2d6"
@@ -7413,6 +7430,8 @@ name = "pendulum-node"
 version = "0.1.0"
 dependencies = [
  "amplitude-runtime",
+ "bifrost-farming-rpc-api",
+ "bifrost-farming-rpc-runtime-api",
  "clap",
  "cumulus-client-cli",
  "cumulus-client-consensus-aura",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -86,6 +86,10 @@ cumulus-relay-chain-interface = { git = "https://github.com/paritytech/cumulus.g
 cumulus-relay-chain-rpc-interface = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.37" }
 cumulus-relay-chain-minimal-node = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.37" }
 
+#bifrost
+bifrost-farming-rpc-api = { git = "https://github.com/pendulum-chain/bifrost", branch = "introduce-abstraction-for-currency-id"  }
+bifrost-farming-rpc-runtime-api = { git = "https://github.com/pendulum-chain/bifrost", branch = "introduce-abstraction-for-currency-id" }
+
 [build-dependencies]
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -492,7 +492,7 @@ where
 				deny_unsafe,
 			};
 
-			crate::rpc::create_full_spacewalk(deps).map_err(Into::into)
+			crate::rpc::create_full_spacewalk_foucoco(deps).map_err(Into::into)
 		})
 	};
 


### PR DESCRIPTION
- add bifrost farming dependency to `pendulum node` for foucoco runtime.
- dublicate create_full_spacewalk and create `create_full_spacewalk_foucoco` that will contains unique RPC endpoints for the current stage of foucoco runtime and dependencies