### PR TITLE
increase contract function parameter limit

### DIFF
--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -925,7 +925,13 @@ parameter_types! {
 		.get(DispatchClass::Normal)
 		.max_total
 		.unwrap_or(RuntimeBlockWeights::get().max_block);
-	pub Schedule: pallet_contracts::Schedule<Runtime> = Default::default();
+	pub Schedule: pallet_contracts::Schedule<Runtime> = pallet_contracts::Schedule::<Runtime>{
+		limits: pallet_contracts::Limits{
+			parameters: 16,
+			..Default::default()
+		},
+		..Default::default()
+	};
 }
 
 pub type CurrencyTypeId = u8;


### PR DESCRIPTION
increases the contract function parameter limit to 16, to match ethereum's limit.

This is needed because 0xAmber is blocked because it has functions with more parameters than our current limit.
See: https://github.com/pendulum-chain/pendulum/issues/225#issuecomment-1542493083