### PR TITLE
adjust contract parameter limit

### DIFF
--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -246,10 +246,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("amplitude"),
 	impl_name: create_runtime_str!("amplitude"),
 	authoring_version: 1,
-	spec_version: 11,
+	spec_version: 12,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 22,
+	transaction_version: 23,
 	state_version: 1,
 };
 
@@ -926,7 +926,7 @@ parameter_types! {
 		.unwrap_or(RuntimeBlockWeights::get().max_block);
 	pub Schedule: pallet_contracts::Schedule<Runtime> = pallet_contracts::Schedule::<Runtime>{
 		limits: pallet_contracts::Limits{
-			parameters: 16,
+			parameters: 256,
 			..Default::default()
 		},
 		..Default::default()


### PR DESCRIPTION
I had to adjust the contract function parameter limit again. Despite the comments around it, it turns out the limit actually refers to the number of registers, not the number of parameters. (depending on the type, a parameter can use multiple registers) 128 still wasn't enough, but 256 worked. 

I also bumped the spec_version to deploy it to Foucoco.

Refer to: https://github.com/pendulum-chain/pendulum/issues/225