### PR TITLE
230 use currencyid in chain extensions

### DIFF
--- a/runtime/common/src/chain_ext.rs
+++ b/runtime/common/src/chain_ext.rs
@@ -186,39 +186,8 @@ impl From<dia::CoinInfo> for CoinInfo {
 	}
 }
 
-/// DecodeByteReader is used for reading a Vec<u8>. It implements codec::Input, which is needed by T::decode() to decode scale encoded types.
-pub struct DecodeByteReader {
-	remaining_len: usize,
-	vec: Vec<u8>,
-}
-impl DecodeByteReader {
-	pub fn new(vec: Vec<u8>) -> Self {
-		Self { remaining_len: vec.len(), vec }
-	}
-}
-// Doc comments passed down from the trait explain what its these functions should do, but basically read() reads the exact number of bytes required to fill the given input buffer. remaining_len() is there to track how much is left to read since the buffer may be smaller than the vec, so it might end up being called multiple times until vec is fully read.
-impl Input for DecodeByteReader {
-	fn remaining_len(&mut self) -> Result<Option<usize>, codec::Error> {
-		Ok(Some(self.remaining_len))
-	}
-	fn read(&mut self, into: &mut [u8]) -> Result<(), codec::Error> {
-		let mut vec_index = self.vec.len() - self.remaining_len;
-		for i in 0..into.len() {
-			if vec_index < self.vec.len() {
-				into[i] = self.vec[vec_index];
-				vec_index += 1;
-			} else {
-				into[i] = 0;
-			}
-		}
-		self.remaining_len = self.vec.len() - vec_index;
-		Ok(())
-	}
-}
-
-/// decode uses DecodeByteReader to decode a Vec<u8> into its scale encoded type.
+/// decode gets the slice from a Vec<u8> to decode it into its scale encoded type.
 pub fn decode<T: Decode>(input: Vec<u8>) -> Result<T, codec::Error> {
-	let mut reader = DecodeByteReader::new(input.clone());
-	let value: T = T::decode(&mut reader)?;
-	return Ok(value)
+	let mut input = input.as_slice();
+	T::decode(&mut input)
 }

--- a/runtime/common/src/chain_ext.rs
+++ b/runtime/common/src/chain_ext.rs
@@ -8,9 +8,19 @@ use dia_oracle::dia;
 pub use spacewalk_primitives::{Asset, CurrencyId};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub enum OriginType {
 	Caller,
 	Address,
+}
+impl From<u8> for OriginType {
+	fn from(origin: u8) -> OriginType {
+		if origin == 0 {
+			OriginType::Caller
+		} else {
+			OriginType::Address
+		}
+	}
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
@@ -211,3 +221,6 @@ pub fn decode<T : Decode>(input: Vec<u8>) -> Result<T, codec::Error> {
 	let value: T = T::decode(&mut reader)?;
 	return Ok(value)
 }
+
+pub type Address = [u8; 32];
+pub type Amount = u128;

--- a/runtime/common/src/chain_ext.rs
+++ b/runtime/common/src/chain_ext.rs
@@ -1,9 +1,9 @@
 use crate::*;
-use codec::{Input};
-use sp_core::{Decode, Encode, MaxEncodedLen};
-use sp_runtime::{ArithmeticError, TokenError, codec};
-use scale_info::prelude::vec::Vec;
+use codec::Input;
 use dia_oracle::dia;
+use scale_info::prelude::vec::Vec;
+use sp_core::{Decode, Encode, MaxEncodedLen};
+use sp_runtime::{codec, ArithmeticError, TokenError};
 
 pub use spacewalk_primitives::{Asset, CurrencyId};
 
@@ -186,37 +186,34 @@ impl From<dia::CoinInfo> for CoinInfo {
 	}
 }
 
-pub struct DecodeByteReader{
-    remaining_len: usize,
-    vec: Vec<u8>,
+pub struct DecodeByteReader {
+	remaining_len: usize,
+	vec: Vec<u8>,
 }
 impl DecodeByteReader {
-    pub fn new(vec: Vec<u8>) -> Self {
-        Self {
-            remaining_len: vec.len(),
-            vec,
-        }
-    }
+	pub fn new(vec: Vec<u8>) -> Self {
+		Self { remaining_len: vec.len(), vec }
+	}
 }
 impl Input for DecodeByteReader {
-    fn remaining_len(&mut self) -> Result<Option<usize>, codec::Error> {
-        Ok(Some(self.remaining_len))
-    }
-    fn read(&mut self, into: &mut [u8]) -> Result<(), codec::Error> {
-        let mut vec_index = self.vec.len() - self.remaining_len;
-        for i in 0..into.len() {
-            if vec_index < self.vec.len() {
-                into[i] = self.vec[vec_index];
-                vec_index += 1;
-            } else {
-                into[i] = 0;
-            }
-        }
-        self.remaining_len = self.vec.len() - vec_index;
-        Ok(())
-    }
+	fn remaining_len(&mut self) -> Result<Option<usize>, codec::Error> {
+		Ok(Some(self.remaining_len))
+	}
+	fn read(&mut self, into: &mut [u8]) -> Result<(), codec::Error> {
+		let mut vec_index = self.vec.len() - self.remaining_len;
+		for i in 0..into.len() {
+			if vec_index < self.vec.len() {
+				into[i] = self.vec[vec_index];
+				vec_index += 1;
+			} else {
+				into[i] = 0;
+			}
+		}
+		self.remaining_len = self.vec.len() - vec_index;
+		Ok(())
+	}
 }
-pub fn decode<T : Decode>(input: Vec<u8>) -> Result<T, codec::Error> {
+pub fn decode<T: Decode>(input: Vec<u8>) -> Result<T, codec::Error> {
 	let mut reader = DecodeByteReader::new(input.clone());
 	let value: T = T::decode(&mut reader)?;
 	return Ok(value)

--- a/runtime/common/src/chain_ext.rs
+++ b/runtime/common/src/chain_ext.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use codec::{Input};
 use sp_core::{Decode, Encode, MaxEncodedLen};
 use sp_runtime::{ArithmeticError, TokenError, codec};
 use scale_info::prelude::vec::Vec;
@@ -173,4 +174,40 @@ impl From<dia::CoinInfo> for CoinInfo {
 			price: coin_info.price,
 		}
 	}
+}
+
+pub struct DecodeByteReader{
+    remaining_len: usize,
+    vec: Vec<u8>,
+}
+impl DecodeByteReader {
+    pub fn new(vec: Vec<u8>) -> Self {
+        Self {
+            remaining_len: vec.len(),
+            vec,
+        }
+    }
+}
+impl Input for DecodeByteReader {
+    fn remaining_len(&mut self) -> Result<Option<usize>, codec::Error> {
+        Ok(Some(self.remaining_len))
+    }
+    fn read(&mut self, into: &mut [u8]) -> Result<(), codec::Error> {
+        let mut vec_index = self.vec.len() - self.remaining_len;
+        for i in 0..into.len() {
+            if vec_index < self.vec.len() {
+                into[i] = self.vec[vec_index];
+                vec_index += 1;
+            } else {
+                into[i] = 0;
+            }
+        }
+        self.remaining_len = self.vec.len() - vec_index;
+        Ok(())
+    }
+}
+pub fn decode<T : Decode>(input: Vec<u8>) -> Result<T, codec::Error> {
+	let mut reader = DecodeByteReader::new(input.clone());
+	let value: T = T::decode(&mut reader)?;
+	return Ok(value)
 }

--- a/runtime/common/src/chain_ext.rs
+++ b/runtime/common/src/chain_ext.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use sp_core::{Decode, Encode, MaxEncodedLen};
 use sp_runtime::{ArithmeticError, TokenError};
-use spacewalk_primitives::{Asset, CurrencyId};
+pub use spacewalk_primitives::{Asset, CurrencyId};
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
 pub enum OriginType {
 	Caller,
@@ -118,26 +118,5 @@ impl From<TokenError> for PalletAssetTokenError {
 			TokenError::Frozen => PalletAssetTokenError::Frozen,
 			TokenError::Unsupported => PalletAssetTokenError::Unsupported,
 		}
-	}
-}
-
-pub fn try_get_currency_id_from(
-	type_id: u8,
-	code: [u8; 12],
-	issuer: [u8; 32],
-) -> Result<CurrencyId, ()> {
-	match type_id {
-		0 => {
-			let foreign_currency_id = code[0];
-			Ok(CurrencyId::XCM(foreign_currency_id))
-		},
-		1 => Ok(CurrencyId::Native),
-		2 => Ok(CurrencyId::StellarNative),
-		3 => {
-			let code = [code[0], code[1], code[2], code[3]];
-			Ok(CurrencyId::Stellar(Asset::AlphaNum4 { code, issuer }))
-		},
-		4 => Ok(CurrencyId::Stellar(Asset::AlphaNum12 { code, issuer })),
-		_ => Err(()),
 	}
 }

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -928,10 +928,6 @@ parameter_types! {
 	pub Schedule: pallet_contracts::Schedule<Runtime> = Default::default();
 }
 
-pub type CurrencyTypeId = u8;
-pub type StellarAssetCode = [u8; 12];
-pub type StellarAssetIssuer = [u8; 32];
-
 #[derive(Default)]
 pub struct Psp22Extension;
 
@@ -969,30 +965,19 @@ where
 				let mut env = env.buf_in_buf_out();
 				let create_asset: (
 					OriginType,
-					CurrencyTypeId,
-					StellarAssetCode,
-					StellarAssetIssuer,
+					CurrencyId,
 					T::AccountId,
 					BalanceOfForChainExt<T>,
 				) = env.read_as()?;
-				let (origin_id, type_id, code, issuer, account_id, balance) = create_asset;
+				let (origin_id, currency_id, account_id, balance) = create_asset;
 
 				let address_account =
 					if origin_id == OriginType::Caller { caller } else { address };
 
-				warn!("asset_id : {:#?}", type_id);
+				warn!("currency_id : {:#?}", currency_id);
 				warn!("address_account : {:#?}", address_account);
 				warn!("account_id : {:#?}", account_id);
 				warn!("balance : {:#?}", balance);
-
-				let currency_id =
-					try_get_currency_id_from(type_id, code, issuer).map_err(|_| {
-						error!(
-						"Currency ID does not exist! type_id : {}, code : {:#?}, issuer : {:#?}",
-						type_id, code, issuer
-					);
-						DispatchError::Other("Currency id does not exist")
-					})?;
 
 				let is_allowed_currency =
 					orml_currencies_allowance_extension::Pallet::<T>::is_allowed_currency(
@@ -1018,23 +1003,12 @@ where
 			1106 => {
 				let mut env = env.buf_in_buf_out();
 				let create_asset: (
-					CurrencyTypeId,
-					StellarAssetCode,
-					StellarAssetIssuer,
+					CurrencyId,
 					T::AccountId,
 				) = env.read_as()?;
-				let (type_id, code, issuer, account_id) = create_asset;
+				let (currency_id, account_id) = create_asset;
 
-				let currency_id =
-					try_get_currency_id_from(type_id, code, issuer).map_err(|_| {
-						error!(
-						"Currency ID does not exist! type_id : {}, code : {:#?}, issuer : {:#?}",
-						type_id, code, issuer
-					);
-						DispatchError::Other("Currency id does not exist")
-					})?;
-
-				warn!("asset_id : {:#?}", type_id);
+				warn!("currency_id : {:#?}", currency_id);
 				warn!("account_id : {:#?}", account_id);
 
 				let is_allowed_currency =
@@ -1042,7 +1016,7 @@ where
 						currency_id,
 					);
 				if !is_allowed_currency {
-					warn!("asset_id : {:#?} is_allowed_currency: false", type_id);
+					warn!("asset_id : {:#?} is_allowed_currency: false", currency_id);
 					return Err(DispatchError::Other(
 						"Currency id is not allowed for chain extension",
 					))
@@ -1064,21 +1038,10 @@ where
 			1107 => {
 				let mut env = env.buf_in_buf_out();
 				let create_asset: (
-					CurrencyTypeId,
-					StellarAssetCode,
-					StellarAssetIssuer,
+					CurrencyId,
 					T::AccountId,
 				) = env.read_as()?;
-				let (type_id, code, issuer, _account_id) = create_asset;
-
-				let currency_id =
-					try_get_currency_id_from(type_id, code, issuer).map_err(|_| {
-						error!(
-						"Currency ID does not exist! type_id : {}, code : {:#?}, issuer : {:#?}",
-						type_id, code, issuer
-					);
-						DispatchError::Other("Currency id does not exist")
-					})?;
+				let (currency_id, _account_id) = create_asset;
 
 				let is_allowed_currency =
 					orml_currencies_allowance_extension::Pallet::<T>::is_allowed_currency(
@@ -1108,13 +1071,11 @@ where
 				let mut env = env.buf_in_buf_out();
 				let create_asset: (
 					OriginType,
-					CurrencyTypeId,
-					StellarAssetCode,
-					StellarAssetIssuer,
+					CurrencyId,
 					T::AccountId,
 					BalanceOfForChainExt<T>,
 				) = env.read_as()?;
-				let (origin_type, type_id, code, issuer, to, amount) = create_asset;
+				let (origin_type, currency_id, to, amount) = create_asset;
 
 				let from = if origin_type == OriginType::Caller { caller } else { address };
 
@@ -1122,15 +1083,6 @@ where
 				warn!("origin_type : {:#?}", origin_type);
 				warn!("to : {:#?}", to);
 				warn!("amount : {:#?}", amount);
-
-				let currency_id =
-					try_get_currency_id_from(type_id, code, issuer).map_err(|_| {
-						error!(
-						"Currency ID does not exist! type_id : {}, code : {:#?}, issuer : {:#?}",
-						type_id, code, issuer
-					);
-						DispatchError::Other("Currency id does not exist")
-					})?;
 
 				let is_allowed_currency =
 					orml_currencies_allowance_extension::Pallet::<T>::is_allowed_currency(
@@ -1174,15 +1126,13 @@ where
 					T::AccountId,
 					(
 						OriginType,
-						CurrencyTypeId,
-						StellarAssetCode,
-						StellarAssetIssuer,
+						CurrencyId,
 						T::AccountId,
 						BalanceOfForChainExt<T>,
 					),
 				) = env.read_as()?;
 				let owner = create_asset.0;
-				let (origin_type, type_id, code, issuer, to, amount) = create_asset.1;
+				let (origin_type, currency_id, to, amount) = create_asset.1;
 
 				let from = if origin_type == OriginType::Caller { caller } else { address };
 
@@ -1191,15 +1141,6 @@ where
 				warn!("origin_type : {:#?}", origin_type);
 				warn!("to : {:#?}", to);
 				warn!("amount : {:#?}", amount);
-
-				let currency_id =
-					try_get_currency_id_from(type_id, code, issuer).map_err(|_| {
-						error!(
-						"Currency ID does not exist! type_id : {}, code : {:#?}, issuer : {:#?}",
-						type_id, code, issuer
-					);
-						DispatchError::Other("Currency id does not exist")
-					})?;
 
 				let is_allowed_currency =
 					orml_currencies_allowance_extension::Pallet::<T>::is_allowed_currency(
@@ -1239,25 +1180,12 @@ where
 			1110 => {
 				let mut env = env.buf_in_buf_out();
 				let allowance_request: (
-					CurrencyTypeId,
-					StellarAssetCode,
-					StellarAssetIssuer,
+					CurrencyId,
 					T::AccountId,
 					T::AccountId,
 				) = env.read_as()?;
-
-				let currency_id = try_get_currency_id_from(
-					allowance_request.0,
-					allowance_request.1,
-					allowance_request.2,
-				)
-				.map_err(|_| {
-					error!(
-						"Currency ID does not exist! type_id : {}, code : {:#?}, issuer : {:#?}",
-						allowance_request.0, allowance_request.1, allowance_request.2
-					);
-					DispatchError::Other("Currency id does not exist")
-				})?;
+				warn!("allowance_request : {:#?}", allowance_request);	
+				let (currency_id, owner, delegate) = allowance_request;
 
 				let is_allowed_currency =
 					orml_currencies_allowance_extension::Pallet::<T>::is_allowed_currency(
@@ -1271,10 +1199,9 @@ where
 
 				let allowance = orml_currencies_allowance_extension::Pallet::<T>::allowance(
 					currency_id,
-					&allowance_request.3,
-					&allowance_request.4,
+					&owner,
+					&delegate,
 				);
-				warn!("allowance_request : {:#?}", allowance_request);
 				warn!("allowance : {:#?}", allowance);
 
 				env.write(&allowance.encode(), false, None)

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -969,7 +969,7 @@ where
 				let address = ext.address().clone();
 				let caller = ext.caller().clone();
 
-				let mut env = env.buf_in_buf_out();
+				let env = env.buf_in_buf_out();
 				let input = env.read(256)?;
 				let (origin_id, currency_id, account_id, balance): (
 					OriginType,
@@ -1134,14 +1134,12 @@ where
 
 				let mut env = env.buf_in_buf_out();
 				let input = env.read(256)?;
-				let (owner, (origin_type, currency_id, to, amount)): (
+				let (owner, origin_type, currency_id, to, amount): (
 					T::AccountId,
-					(
-						OriginType,
-						CurrencyId,
-						T::AccountId,
-						BalanceOfForChainExt<T>,
-					),
+					OriginType,
+					CurrencyId,
+					T::AccountId,
+					BalanceOfForChainExt<T>,
 				) = chain_ext::decode(input).map_err(|_| {
 					DispatchError::Other("ChainExtension failed to decode input")
 				})?;

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -59,9 +59,8 @@ use frame_system::{
 pub use sp_runtime::{MultiAddress, Perbill, Permill, Perquintill};
 
 use runtime_common::{
-	opaque, AccountId, Amount, AuraId, Balance, BlockNumber, Hash, Index, PoolId,
+	chain_ext, opaque, AccountId, Amount, AuraId, Balance, BlockNumber, Hash, Index, PoolId,
 	ReserveIdentifier, Signature, EXISTENTIAL_DEPOSIT, MICROUNIT, MILLIUNIT, NANOUNIT, UNIT,
-	chain_ext,
 };
 
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
@@ -976,9 +975,8 @@ where
 					CurrencyId,
 					T::AccountId,
 					BalanceOfForChainExt<T>,
-				) = chain_ext::decode(input).map_err(|_| {
-					DispatchError::Other("ChainExtension failed to decode input")
-				})?;
+				) = chain_ext::decode(input)
+					.map_err(|_| DispatchError::Other("ChainExtension failed to decode input"))?;
 
 				let address_account =
 					if origin_id == OriginType::Caller { caller } else { address };
@@ -1012,9 +1010,10 @@ where
 			1106 => {
 				let mut env = env.buf_in_buf_out();
 				let input = env.read(256)?;
-				let (currency_id, account_id): (CurrencyId, T::AccountId) = chain_ext::decode(input).map_err(|_| {
-					DispatchError::Other("ChainExtension failed to decode input")
-				})?;
+				let (currency_id, account_id): (CurrencyId, T::AccountId) =
+					chain_ext::decode(input).map_err(|_| {
+						DispatchError::Other("ChainExtension failed to decode input")
+					})?;
 
 				warn!("currency_id : {:#?}", currency_id);
 				warn!("account_id : {:#?}", account_id);
@@ -1046,9 +1045,8 @@ where
 			1107 => {
 				let mut env = env.buf_in_buf_out();
 				let input = env.read(256)?;
-				let currency_id: CurrencyId = chain_ext::decode(input).map_err(|_| {
-					DispatchError::Other("ChainExtension failed to decode input")
-				})?;
+				let currency_id: CurrencyId = chain_ext::decode(input)
+					.map_err(|_| DispatchError::Other("ChainExtension failed to decode input"))?;
 
 				let is_allowed_currency =
 					orml_currencies_allowance_extension::Pallet::<T>::is_allowed_currency(
@@ -1083,9 +1081,8 @@ where
 					CurrencyId,
 					T::AccountId,
 					BalanceOfForChainExt<T>,
-				) = chain_ext::decode(input).map_err(|_| {
-					DispatchError::Other("ChainExtension failed to decode input")
-				})?;
+				) = chain_ext::decode(input)
+					.map_err(|_| DispatchError::Other("ChainExtension failed to decode input"))?;
 
 				let from = if origin_type == OriginType::Caller { caller } else { address };
 
@@ -1140,9 +1137,8 @@ where
 					CurrencyId,
 					T::AccountId,
 					BalanceOfForChainExt<T>,
-				) = chain_ext::decode(input).map_err(|_| {
-					DispatchError::Other("ChainExtension failed to decode input")
-				})?;
+				) = chain_ext::decode(input)
+					.map_err(|_| DispatchError::Other("ChainExtension failed to decode input"))?;
 
 				let from = if origin_type == OriginType::Caller { caller } else { address };
 
@@ -1190,13 +1186,10 @@ where
 			1110 => {
 				let mut env = env.buf_in_buf_out();
 				let input = env.read(256)?;
-				let (currency_id, owner, delegate): (
-					CurrencyId,
-					T::AccountId,
-					T::AccountId,
-				) = chain_ext::decode(input).map_err(|_| {
-					DispatchError::Other("ChainExtension failed to decode input")
-				})?;
+				let (currency_id, owner, delegate): (CurrencyId, T::AccountId, T::AccountId) =
+					chain_ext::decode(input).map_err(|_| {
+						DispatchError::Other("ChainExtension failed to decode input")
+					})?;
 
 				let is_allowed_currency =
 					orml_currencies_allowance_extension::Pallet::<T>::is_allowed_currency(
@@ -1224,8 +1217,10 @@ where
 				let mut env = env.buf_in_buf_out();
 				let (blockchain, symbol): (Blockchain, Symbol) = env.read_as()?;
 
-				let result =
-					<dia_oracle::Pallet<T> as DiaOracle>::get_coin_info(blockchain.to_trimmed_vec(), symbol.to_trimmed_vec());
+				let result = <dia_oracle::Pallet<T> as DiaOracle>::get_coin_info(
+					blockchain.to_trimmed_vec(),
+					symbol.to_trimmed_vec(),
+				);
 
 				warn!("blockchain: {:#?}, symbol: {:#?}", blockchain, symbol);
 				warn!("price_feed: {:#?}", result);


### PR DESCRIPTION
Relating to: https://github.com/pendulum-chain/pendulum/issues/230
updates the chain extensions to take CurrencyId instead of using a mapping to it.

the ink contract is updated to work with CurrencyId in https://github.com/pendulum-chain/pendulum-ink-wrapper/tree/use-currencyid
I already tested that it all works locally. I will create the PR for that one after this one is merged.