### PR TITLE
244 perform runtime upgrade on foucoco to include latest changes to the chain extension

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -10,13 +10,19 @@ on:
 
 jobs:
   test-code:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Freeing up more disk space
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+
+      - name: Install package
+        run: |
+          echo 'APT::Get::Always-Include-Phased-Updates "false";' | sudo tee /etc/apt/apt.conf.d/99-phased-updates
+          sudo apt-get update && sudo apt-get upgrade -y
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev
 
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/runtime/common/src/chain_ext.rs
+++ b/runtime/common/src/chain_ext.rs
@@ -1,5 +1,4 @@
 use crate::*;
-use codec::Input;
 use dia_oracle::dia;
 use scale_info::prelude::vec::Vec;
 use sp_core::{Decode, Encode, MaxEncodedLen};

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -60,7 +60,7 @@ pub use sp_runtime::{MultiAddress, Perbill, Permill, Perquintill};
 
 use runtime_common::{
 	chain_ext, opaque, AccountId, Amount, AuraId, Balance, BlockNumber, Hash, Index, PoolId,
-	ReserveIdentifier, Signature, EXISTENTIAL_DEPOSIT, MICROUNIT, MILLIUNIT, NANOUNIT, UNIT,
+	ReserveIdentifier, Signature, EXISTENTIAL_DEPOSIT, MILLIUNIT, NANOUNIT, UNIT,
 };
 
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -246,10 +246,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("amplitude"),
 	impl_name: create_runtime_str!("amplitude"),
 	authoring_version: 1,
-	spec_version: 12,
+	spec_version: 13,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 23,
+	transaction_version: 24,
 	state_version: 1,
 };
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -3,6 +3,3 @@ channel = "nightly-2022-12-12"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"
-
-[target.armv7-unknown-linux-gnueabi]
-linker = "arm-linux-gnueabi-gcc"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -3,3 +3,6 @@ channel = "nightly-2022-12-12"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"
+
+[target.armv7-unknown-linux-gnueabi]
+linker = "arm-linux-gnueabi-gcc"


### PR DESCRIPTION
I performed this runtime upgrade to get the latest changes to the chain extension live on Foucoco.

Closes #244.