### PR TITLE
Remove `origin_type` and refactor chain extension **on Foucoco**

### DIFF
--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -59,7 +59,7 @@ pub use sp_runtime::{MultiAddress, Perbill, Permill, Perquintill};
 
 use runtime_common::{
 	opaque, AccountId, Amount, AuraId, Balance, BlockNumber, Hash, Index, ReserveIdentifier,
-	Signature, EXISTENTIAL_DEPOSIT, MICROUNIT, MILLIUNIT, NANOUNIT, UNIT,
+	Signature, EXISTENTIAL_DEPOSIT, MILLIUNIT, NANOUNIT, UNIT,
 };
 
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;

--- a/runtime/common/src/chain_ext.rs
+++ b/runtime/common/src/chain_ext.rs
@@ -121,6 +121,19 @@ impl From<ArithmeticError> for ChainExtensionArithmeticError {
 	}
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum ChainExtensionCustomTokenError {
+	/// Decoding failed.
+	DecodeFailed,
+	/// Currency not allowed.
+	CurrencyNotAllowed,
+	/// Call to pallet failed.
+	PalletCallFailed,
+	/// Unknown error
+	Unknown,
+}
+
 /// ToTrimmedVec is a trait implemented for [u8; 32] to allow both types Blockchain and Symbol (which are [u8; 32]) to have the trim_trailing_zeros function.
 pub trait ToTrimmedVec {
 	fn to_trimmed_vec(&self) -> Vec<u8>;

--- a/runtime/common/src/chain_ext.rs
+++ b/runtime/common/src/chain_ext.rs
@@ -121,19 +121,6 @@ impl From<ArithmeticError> for ChainExtensionArithmeticError {
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
-#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-pub enum ChainExtensionCustomTokenError {
-	/// Decoding failed.
-	DecodeFailed,
-	/// Currency not allowed.
-	CurrencyNotAllowed,
-	/// Call to pallet failed.
-	PalletCallFailed,
-	/// Unknown error
-	Unknown,
-}
-
 /// ToTrimmedVec is a trait implemented for [u8; 32] to allow both types Blockchain and Symbol (which are [u8; 32]) to have the trim_trailing_zeros function.
 pub trait ToTrimmedVec {
 	fn to_trimmed_vec(&self) -> Vec<u8>;

--- a/runtime/common/src/chain_ext.rs
+++ b/runtime/common/src/chain_ext.rs
@@ -15,23 +15,6 @@ pub type Blockchain = [u8; 32];
 /// Symbol is a type alias for easier readability of dia blockchain symbol communicated between contract and chain extension.
 pub type Symbol = [u8; 32];
 
-/// OriginType is the origin type that is communicated between contract and chain extension. It implements From<u8> because it is stored as u8 in contract memory.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
-#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-pub enum OriginType {
-	Caller,
-	Address,
-}
-impl From<u8> for OriginType {
-	fn from(origin: u8) -> OriginType {
-		if origin == 0 {
-			OriginType::Caller
-		} else {
-			OriginType::Address
-		}
-	}
-}
-
 /// ChainExtensionError is almost the same as DispatchError, but with some modifications to make it compatible with being communicated between contract and chain extension. It implements the necessary From<T> conversions with DispatchError and other nested errors.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -991,14 +991,12 @@ where
 					))
 				}
 
-				let result = <orml_currencies::Pallet<T> as MultiCurrency<T::AccountId>>::transfer(
+				<orml_currencies::Pallet<T> as MultiCurrency<T::AccountId>>::transfer(
 					currency_id,
 					&caller,
 					&to,
 					balance,
-				);
-
-				warn!("transfer_result: {:#?}", result);
+				)?;
 			},
 
 			//balance
@@ -1090,26 +1088,12 @@ where
 					))
 				}
 
-				let result = orml_currencies_allowance_extension::Pallet::<T>::do_approve_transfer(
+				orml_currencies_allowance_extension::Pallet::<T>::do_approve_transfer(
 					currency_id,
 					&caller,
 					&to,
 					amount,
-				);
-
-				warn!("approve_transfer : {:#?}", result);
-
-				match result {
-					DispatchResult::Ok(_) => {},
-					DispatchResult::Err(e) => {
-						let err =
-							Result::<(), ChainExtensionError>::Err(ChainExtensionError::from(e));
-						env.write(&err.encode(), false, None).map_err(|_| {
-							error!("ChainExtension failed to call 'approve'");
-							DispatchError::Other("ChainExtension failed to call 'approve'")
-						})?;
-					},
-				}
+				)?;
 			},
 
 			//transfer_approved
@@ -1143,28 +1127,13 @@ where
 					))
 				}
 
-				let result = orml_currencies_allowance_extension::Pallet::<T>::do_transfer_approved(
+				orml_currencies_allowance_extension::Pallet::<T>::do_transfer_approved(
 					currency_id,
 					&owner,
 					&caller,
 					&to,
 					amount,
-				);
-
-				warn!("transfer_from : {:#?}", result);
-
-				match result {
-					DispatchResult::Ok(_) => {},
-					DispatchResult::Err(e) => {
-						let err =
-							Result::<(), ChainExtensionError>::Err(ChainExtensionError::from(e));
-						env.write(&err.encode(), false, None).map_err(|_| {
-							DispatchError::Other(
-								"ChainExtension failed to call 'approved transfer'",
-							)
-						})?;
-					},
-				}
+				)?;
 			},
 
 			//allowance

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1150,7 +1150,7 @@ where
 			},
 
 			// get_coin_info(blockchain, symbol)
-			1201 => {
+			1200 => {
 				let mut env = env.buf_in_buf_out();
 				let (blockchain, symbol): (Blockchain, Symbol) = env.read_as()?;
 

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1113,7 +1113,7 @@ where
 					amount,
 				)?;
 			},
-			// transfer_from(currency, sender, recipient, amount)
+			// transfer_from(sender, currency, recipient, amount)
 			1106 => {
 				let ext = env.ext();
 				let caller = ext.caller().clone();
@@ -1149,8 +1149,8 @@ where
 				)?;
 			},
 
-			//dia price feed
-			7777 => {
+			// get_coin_info(blockchain, symbol)
+			1201 => {
 				let mut env = env.buf_in_buf_out();
 				let (blockchain, symbol): (Blockchain, Symbol) = env.read_as()?;
 
@@ -1159,8 +1159,7 @@ where
 					symbol.to_trimmed_vec(),
 				);
 
-				warn!("blockchain: {:#?}, symbol: {:#?}", blockchain, symbol);
-				warn!("price_feed: {:#?}", result);
+				warn!("Calling get_coin_info() for: {:?}:{:?}", blockchain, symbol);
 
 				let result = match result {
 					Ok(coin_info) =>

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1129,8 +1129,8 @@ where
 					.map_err(|_| DispatchError::Other("ChainExtension failed to decode input"))?;
 
 				warn!(
-					"Calling transfer_from() sending {:?} {:?}, from {:?} to {:?}",
-					amount, currency_id, owner, recipient
+					"Calling transfer_from() for caller {:?}, sending {:?} {:?}, from {:?} to {:?}",
+					caller, amount, currency_id, owner, recipient
 				);
 
 				ensure!(

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -967,7 +967,7 @@ where
 				let mut env = env.buf_in_buf_out();
 				let input = env.read(256)?;
 				let currency_id: CurrencyId = chain_ext::decode(input)
-					.map_err(|_| ChainExtensionCustomTokenError::DecodeFailed)?;
+					.map_err(|_| DispatchError::Other("ChainExtension failed to decode input"))?;
 
 				warn!("Calling totalSupply() for currency {:?}", currency_id);
 
@@ -1024,7 +1024,7 @@ where
 
 				let env = env.buf_in_buf_out();
 				let input = env.read(256)?;
-				let (currency_id, recipient, balance): (
+				let (currency_id, recipient, amount): (
 					CurrencyId,
 					T::AccountId,
 					BalanceOfForChainExt<T>,
@@ -1047,7 +1047,7 @@ where
 					currency_id,
 					&caller,
 					&recipient,
-					balance,
+					amount,
 				)?;
 			},
 			// allowance(currency, owner, spender)
@@ -1085,7 +1085,7 @@ where
 				let ext = env.ext();
 				let caller = ext.caller().clone();
 
-				let mut env = env.buf_in_buf_out();
+				let env = env.buf_in_buf_out();
 				let input = env.read(256)?;
 				let (currency_id, spender, amount): (
 					CurrencyId,
@@ -1116,10 +1116,9 @@ where
 			// transfer_from(currency, sender, recipient, amount)
 			1106 => {
 				let ext = env.ext();
-				let address = ext.address().clone();
 				let caller = ext.caller().clone();
 
-				let mut env = env.buf_in_buf_out();
+				let env = env.buf_in_buf_out();
 				let input = env.read(256)?;
 				let (owner, currency_id, recipient, amount): (
 					T::AccountId,


### PR DESCRIPTION
This PR removes the `OriginType` field from our chain extension functions, as we don't need it.
It also refactors the code, reordering the functions in accordance with their order in [the ERC20 contract](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol), and changes the logged warn messages.

I also intended to improve the error handling but apparently, this is not yet possible, because we cannot define custom error types in our runtime, see [this](https://substrate.stackexchange.com/questions/5839/runtimeerror-type) thread.

- [ ] ~~I think I will try to extract the chain-extension code to a separate directory, similar to what Astar did [here](https://github.com/AstarNetwork/Astar/tree/master/chain-extensions). That way we don't have to duplicate code for our runtimes.~~ Follow-up ticket is #249.

Closes #247.