### PR TITLE
Add Bifrost's farming pallet to Amplitude runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,8 @@ checksum = "4436e0292ab1bb631b42973c61205e704475fe8126af845c8d923c0996328127"
 name = "amplitude-runtime"
 version = "0.1.0"
 dependencies = [
+ "bifrost-farming",
+ "bifrost-farming-rpc-runtime-api",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -140,6 +140,7 @@ where
 		H256,
 		RedeemRequest<AccountId, BlockNumber, Balance, CurrencyId>,
 	>,
+	C::Api: FarmingRuntimeApi<Block, AccountId, PoolId, CurrencyId>,
 	C::Api: module_oracle_rpc::OracleRuntimeApi<Block, Balance, CurrencyId>,
 	C::Api: BlockBuilder<Block>,
 	C::Api: ZenlinkProtocolRuntimeApi<Block, AccountId, AssetId>,
@@ -163,6 +164,7 @@ where
 	module.merge(Replace::new(client.clone()).into_rpc())?;
 	module.merge(VaultRegistry::new(client.clone()).into_rpc())?;
 	module.merge(Oracle::new(client.clone()).into_rpc())?;
+	module.merge(FarmingRpc::new(client.clone()).into_rpc())?;
 	module.merge(ZenlinkProtocol::new(client).into_rpc())?;
 
 	Ok(module)

--- a/runtime/amplitude/Cargo.toml
+++ b/runtime/amplitude/Cargo.toml
@@ -128,6 +128,9 @@ parachain-info = { git = "https://github.com/paritytech/cumulus", default-featur
 zenlink-protocol = { git = "https://github.com/pendulum-chain/Zenlink-DEX-Module", default-features = false, branch = "polkadot-v0.9.40-protocol" }
 zenlink-protocol-runtime-api = { git = "https://github.com/pendulum-chain/Zenlink-DEX-Module", default-features = false, branch = "polkadot-v0.9.40-protocol" }
 
+bifrost-farming = { git = "https://github.com/pendulum-chain/bifrost", default-features = false, branch = "polkadot-v0.9.40-farming-add-currencyid-generic" }
+bifrost-farming-rpc-runtime-api = { git = "https://github.com/pendulum-chain/bifrost", default-features = false, branch = "polkadot-v0.9.40-farming-add-currencyid-generic" }
+
 [features]
 default = [
     "std",
@@ -201,6 +204,8 @@ std = [
     "xcm/std",
     "zenlink-protocol/std",
     "zenlink-protocol-runtime-api/std",
+    "bifrost-farming/std",
+    "bifrost-farming-rpc-runtime-api/std",
     # custom libraries from spacewalk
     "security/std",
     "staking/std",


### PR DESCRIPTION
Uses the same configuration we have for the farming pallet on Foucoco.

Closes #291.