### PR TITLE
Fix wrong `allowed_currencies_len` variable

### DIFF
--- a/pallets/orml-currencies-allowance-extension/src/lib.rs
+++ b/pallets/orml-currencies-allowance-extension/src/lib.rs
@@ -159,7 +159,7 @@ pub mod pallet {
 
 			// Check if the resulting vector of allowed currencies is less than the maximum allowed.
 			// We check after the insertion to avoid counting duplicates.
-			let allowed_currencies_len: usize = currencies.len();
+			let allowed_currencies_len: usize = AllowedCurrencies::<T>::iter().count();
 			ensure!(
 				allowed_currencies_len <= max_allowed_currencies,
 				Error::<T>::ExceedsNumberOfAllowedCurrencies
@@ -181,6 +181,16 @@ pub mod pallet {
 			currencies: Vec<CurrencyOf<T>>,
 		) -> DispatchResult {
 			ensure_root(origin)?;
+
+			// Check if the supplied amount of currencies is less than the maximum allowed
+			// Although this is not strictly necessary, it is a good sanity check and prevents callers
+			// from using too large currency vectors.
+			let max_allowed_currencies: usize = T::MaxAllowedCurrencies::get() as usize;
+			ensure!(
+				currencies.len() <= max_allowed_currencies,
+				Error::<T>::ExceedsNumberOfAllowedCurrencies
+			);
+
 			for i in currencies.clone() {
 				AllowedCurrencies::<T>::remove(i);
 			}


### PR DESCRIPTION
Changes the `allowed_currencies_len` to use the length of the updated `AllowedCurrencies` for the second size check (instead of doing a redundant check on the passed `currencies` vector).

Also adds a similar check to the `remove_allowed_currencies` extrinsic. While in theory, it would of course never be possible to remove more currencies than are contained in the `AllowedCurrencies` storage item, which is limited to the `MaxAllowedCurrencies` config parameter in our `add_allowed_currencies` function, the caller could still provide a very large _and valid_ `currencies` vector to this function and thus bloat the chain. That's why also checking the max size of the vector makes sense here.

Closes #297.