### PR TITLE
Add `pull_request_template.md`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,6 @@
-<!-- If you added changes to files in the `node` directory, please add the following line to the PR description:
-@pendulum-chain/product: This PR adds changes to the node client that require a **redeployment of the collator nodes**. 
+<!-- If you added changes to files in the `node` directory or any other changes that would require a re-deployment of the collator nodes, please add the following line to the PR description:
+@pendulum-chain/product: This PR adds changes to the node client code that require a **redeployment of the collator nodes** to take effect. 
 Please ensure that the collator nodes are redeployed after this PR is merged.  
--->
-<!-- If you added changes to pallets or files in the `runtime` directory, please add the following line to the PR description:
-@pendulum-chain/product: This PR adds changes to the runtime that require a **runtime upgrade** to take effect.
 -->
 
 <!-- Replace xx with the issue number that is fixed by this pull request. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+<!-- If you added changes to files in the `node` directory, please add the following line to the PR description:
+@pendulum-chain/product: This PR adds changes to the node client that require a **redeployment of the collator nodes**. 
+Please ensure that the collator nodes are redeployed after this PR is merged.  
+-->
+<!-- If you added changes to pallets or files in the `runtime` directory, please add the following line to the PR description:
+@pendulum-chain/product: This PR adds changes to the runtime that require a **runtime upgrade** to take effect.
+-->
+
+<!-- Replace xx with the issue number that is fixed by this pull request. -->
+Closes #xx. 


### PR DESCRIPTION
This PR adds a template for pull requests. The template is supposed to remind and help developers to make the product team aware of important changes so that they can prepare the required follow-up tasks.

Closes #307.