### PR TITLE
Implement new rpc function of spacewalks oracle pallet for all runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ version = "0.1.0"
 dependencies = [
  "bifrost-farming",
  "bifrost-farming-rpc-runtime-api",
+ "clients-info",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -1184,6 +1185,22 @@ name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "clients-info"
+version = "0.1.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
 
 [[package]]
 name = "coarsetime"
@@ -2983,6 +3000,7 @@ version = "0.1.0"
 dependencies = [
  "bifrost-farming",
  "bifrost-farming-rpc-runtime-api",
+ "clients-info",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "currency"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2831,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "fee"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "issue"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -4135,6 +4135,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex",
  "log",
  "oracle",
  "orml-currencies",
@@ -5404,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "module-issue-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "jsonrpsee",
  "module-issue-rpc-runtime-api",
@@ -5417,7 +5418,7 @@ dependencies = [
 [[package]]
 name = "module-issue-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5428,7 +5429,7 @@ dependencies = [
 [[package]]
 name = "module-oracle-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5436,24 +5437,26 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
+ "spacewalk-primitives",
 ]
 
 [[package]]
 name = "module-oracle-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "serde",
  "sp-api",
  "sp-std",
+ "spacewalk-primitives",
 ]
 
 [[package]]
 name = "module-redeem-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "jsonrpsee",
  "module-redeem-rpc-runtime-api",
@@ -5466,7 +5469,7 @@ dependencies = [
 [[package]]
 name = "module-redeem-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5477,7 +5480,7 @@ dependencies = [
 [[package]]
 name = "module-replace-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "jsonrpsee",
  "module-replace-rpc-runtime-api",
@@ -5490,7 +5493,7 @@ dependencies = [
 [[package]]
 name = "module-replace-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5501,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "module-vault-registry-rpc"
 version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5515,7 +5518,7 @@ dependencies = [
 [[package]]
 name = "module-vault-registry-rpc-runtime-api"
 version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "frame-support",
  "module-oracle-rpc-runtime-api",
@@ -5790,7 +5793,7 @@ dependencies = [
 [[package]]
 name = "nomination"
 version = "0.5.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "currency",
  "fee",
@@ -5961,7 +5964,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "oracle"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "currency",
  "dia-oracle",
@@ -7596,6 +7599,7 @@ dependencies = [
  "cumulus-relay-chain-minimal-node",
  "cumulus-relay-chain-rpc-interface",
  "development-runtime",
+ "dia-oracle-runtime-api",
  "foucoco-runtime",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -9482,13 +9486,14 @@ dependencies = [
 [[package]]
 name = "redeem"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "currency",
  "fee",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex",
  "oracle",
  "orml-currencies",
  "orml-tokens",
@@ -9643,13 +9648,14 @@ dependencies = [
 [[package]]
 name = "replace"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "currency",
  "fee",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex",
  "nomination",
  "oracle",
  "orml-currencies",
@@ -9685,7 +9691,7 @@ dependencies = [
 [[package]]
 name = "reward"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11431,7 +11437,7 @@ dependencies = [
 [[package]]
 name = "security"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12473,7 +12479,7 @@ dependencies = [
 [[package]]
 name = "spacewalk-primitives"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "base58",
  "bstringify",
@@ -12534,7 +12540,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staking"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12740,7 +12746,7 @@ dependencies = [
 [[package]]
 name = "stellar-relay"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -13720,7 +13726,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 [[package]]
 name = "vault-registry"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=eae146c3795debfdab7215fa82ff1ffc4c2cae48#eae146c3795debfdab7215fa82ff1ffc4c2cae48"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=6a3b14a33da0a97f391a5a7e689ee658da52da84#6a3b14a33da0a97f391a5a7e689ee658da52da84"
 dependencies = [
  "currency",
  "fee",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,13 +15,14 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.145", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 
-module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
+module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+dia-oracle-runtime-api = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.40" }
 
 # Local
 amplitude-runtime = {path = "../runtime/amplitude"}

--- a/runtime/amplitude/Cargo.toml
+++ b/runtime/amplitude/Cargo.toml
@@ -26,24 +26,24 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # Custom libraries for Spacewalk
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }

--- a/runtime/amplitude/Cargo.toml
+++ b/runtime/amplitude/Cargo.toml
@@ -26,6 +26,7 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # Custom libraries for Spacewalk
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
 currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
 security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
 staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84" }

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1762,6 +1762,11 @@ impl_runtime_apis! {
 			let result = Oracle::usd_to_currency(amount.amount, currency_id)?;
 			Ok(BalanceWrapper{amount:result})
 		}
+
+		fn get_exchange_rate(currency_id: CurrencyId) -> Result<UnsignedFixedPoint, DispatchError> {
+			let result = Oracle::get_exchange_rate(currency_id)?;
+			Ok(result)
+		}
 	}
 
 }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -30,7 +30,7 @@ orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-m
 dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.40" }
 zenlink-protocol = { git = "https://github.com/pendulum-chain/Zenlink-DEX-Module", default-features = false, branch = "polkadot-v0.9.40-protocol" }
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "eae146c3795debfdab7215fa82ff1ffc4c2cae48" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "6a3b14a33da0a97f391a5a7e689ee658da52da84" }
 
 [features]
 default = [

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -26,25 +26,25 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # custom libraries from spacewalk
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
 
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -26,6 +26,7 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # custom libraries from spacewalk
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
 currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
 security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
 staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -2081,6 +2081,11 @@ impl_runtime_apis! {
 			let result = Oracle::usd_to_currency(amount.amount, currency_id)?;
 			Ok(BalanceWrapper{amount:result})
 		}
+
+		fn get_exchange_rate(currency_id: CurrencyId) -> Result<UnsignedFixedPoint, DispatchError> {
+			let result = Oracle::get_exchange_rate(currency_id)?;
+			Ok(result)
+		}
 	}
 
 }

--- a/runtime/pendulum/Cargo.toml
+++ b/runtime/pendulum/Cargo.toml
@@ -26,7 +26,7 @@ smallvec = "1.9.0"
 runtime-common = {path = "../common", default-features = false}
 
 # Spacewalk libraries
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "eae146c3795debfdab7215fa82ff1ffc4c2cae48"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "6a3b14a33da0a97f391a5a7e689ee658da52da84"}
 
 # Substrate
 frame-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40"}


### PR DESCRIPTION
Note: Requires merge spacewalk's [PR #402](https://github.com/pendulum-chain/spacewalk/pull/402), For now I will leave as draft to later point to the corresponding commit rev of spacewalk.

Implements the new RPC function to get exchange rates for Foucoco, Amplitude.
Pendulum runtime does not currently implements `oracle` pallet, this would be required first to implement the new RPC method.

Issue #286

This will require a node redeployment since runtime is modified.