### PR TITLE
Update Spacewalk dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12915,7 +12915,7 @@ dependencies = [
 [[package]]
 name = "substrate-stellar-sdk"
 version = "0.2.4"
-source = "git+https://github.com/pendulum-chain/substrate-stellar-sdk?branch=polkadot-v0.9.40#f306b44f22216e43809e96ad96ae24cf62f6325f"
+source = "git+https://github.com/pendulum-chain/substrate-stellar-sdk?branch=polkadot-v0.9.40#dc4212fc0b9c29d9fd370cde7ba666172de8fb7b"
 dependencies = [
  "base64 0.13.1",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 [[package]]
 name = "clients-info"
 version = "0.1.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "currency"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2848,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "fee"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "issue"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -4172,7 +4172,6 @@ dependencies = [
  "sp-std",
  "spacewalk-primitives",
  "stellar-relay",
- "substrate-stellar-sdk",
  "vault-registry",
 ]
 
@@ -5423,7 +5422,7 @@ dependencies = [
 [[package]]
 name = "module-issue-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "jsonrpsee",
  "module-issue-rpc-runtime-api",
@@ -5436,7 +5435,7 @@ dependencies = [
 [[package]]
 name = "module-issue-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5447,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "module-oracle-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5455,24 +5454,26 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
+ "spacewalk-primitives",
 ]
 
 [[package]]
 name = "module-oracle-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "serde",
  "sp-api",
  "sp-std",
+ "spacewalk-primitives",
 ]
 
 [[package]]
 name = "module-redeem-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "jsonrpsee",
  "module-redeem-rpc-runtime-api",
@@ -5485,7 +5486,7 @@ dependencies = [
 [[package]]
 name = "module-redeem-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5496,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "module-replace-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "jsonrpsee",
  "module-replace-rpc-runtime-api",
@@ -5509,7 +5510,7 @@ dependencies = [
 [[package]]
 name = "module-replace-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5520,7 +5521,7 @@ dependencies = [
 [[package]]
 name = "module-vault-registry-rpc"
 version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5534,7 +5535,7 @@ dependencies = [
 [[package]]
 name = "module-vault-registry-rpc-runtime-api"
 version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "frame-support",
  "module-oracle-rpc-runtime-api",
@@ -5809,7 +5810,7 @@ dependencies = [
 [[package]]
 name = "nomination"
 version = "0.5.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "currency",
  "fee",
@@ -5980,13 +5981,14 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "oracle"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "currency",
  "dia-oracle",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "once_cell",
  "orml-oracle",
  "pallet-balances",
  "pallet-timestamp",
@@ -5999,6 +6001,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "spacewalk-primitives",
+ "spin 0.9.8",
  "staking",
 ]
 
@@ -9501,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "redeem"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "currency",
  "fee",
@@ -9526,7 +9529,6 @@ dependencies = [
  "sp-std",
  "spacewalk-primitives",
  "stellar-relay",
- "substrate-stellar-sdk",
  "vault-registry",
 ]
 
@@ -9663,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "replace"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "currency",
  "fee",
@@ -9689,7 +9691,6 @@ dependencies = [
  "sp-std",
  "spacewalk-primitives",
  "stellar-relay",
- "substrate-stellar-sdk",
  "vault-registry",
 ]
 
@@ -9706,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reward"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11452,7 +11453,7 @@ dependencies = [
 [[package]]
 name = "security"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12494,7 +12495,7 @@ dependencies = [
 [[package]]
 name = "spacewalk-primitives"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "base58",
  "bstringify",
@@ -12520,6 +12521,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -12555,7 +12559,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staking"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12761,7 +12765,7 @@ dependencies = [
 [[package]]
 name = "stellar-relay"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -12775,7 +12779,6 @@ dependencies = [
  "sp-core",
  "sp-std",
  "spacewalk-primitives",
- "substrate-stellar-sdk",
 ]
 
 [[package]]
@@ -13741,7 +13744,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 [[package]]
 name = "vault-registry"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=31df1832483199b978ae07f6ed4e018a11ff4dba#31df1832483199b978ae07f6ed4e018a11ff4dba"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
 dependencies = [
  "currency",
  "fee",
@@ -13768,7 +13771,6 @@ dependencies = [
  "sp-std",
  "spacewalk-primitives",
  "staking",
- "substrate-stellar-sdk",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,13 +15,13 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.145", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 
-module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
+module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
 
 # Local
 amplitude-runtime = {path = "../runtime/amplitude"}

--- a/runtime/amplitude/Cargo.toml
+++ b/runtime/amplitude/Cargo.toml
@@ -26,25 +26,25 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # Custom libraries for Spacewalk
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba" }
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1195,10 +1195,10 @@ impl replace::Config for Runtime {
 }
 
 impl clients_info::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type WeightInfo = clients_info::SubstrateWeight<Runtime>;
-    type MaxNameLength = ConstU32<255>;
-    type MaxUriLength = ConstU32<255>;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = clients_info::SubstrateWeight<Runtime>;
+	type MaxNameLength = ConstU32<255>;
+	type MaxUriLength = ConstU32<255>;
 }
 
 parameter_types! {
@@ -1770,6 +1770,11 @@ impl_runtime_apis! {
 		fn usd_to_currency(amount:BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
 			let result = Oracle::usd_to_currency(amount.amount, currency_id)?;
 			Ok(BalanceWrapper{amount:result})
+		}
+
+		fn get_exchange_rate(currency_id: CurrencyId) -> Result<UnsignedFixedPoint, DispatchError> {
+			let result = Oracle::get_exchange_rate(currency_id)?;
+			Ok(result)
 		}
 	}
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -30,7 +30,7 @@ orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-m
 dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.40" }
 zenlink-protocol = { git = "https://github.com/pendulum-chain/Zenlink-DEX-Module", default-features = false, branch = "polkadot-v0.9.40-protocol" }
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "31df1832483199b978ae07f6ed4e018a11ff4dba" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
 
 [features]
 default = [

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -26,26 +26,26 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # custom libraries from spacewalk
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
 
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1504,10 +1504,10 @@ impl replace::Config for Runtime {
 }
 
 impl clients_info::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type WeightInfo = clients_info::SubstrateWeight<Runtime>;
-    type MaxNameLength = ConstU32<255>;
-    type MaxUriLength = ConstU32<255>;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = clients_info::SubstrateWeight<Runtime>;
+	type MaxNameLength = ConstU32<255>;
+	type MaxUriLength = ConstU32<255>;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
@@ -2089,6 +2089,11 @@ impl_runtime_apis! {
 		fn usd_to_currency(amount:BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
 			let result = Oracle::usd_to_currency(amount.amount, currency_id)?;
 			Ok(BalanceWrapper{amount:result})
+		}
+
+		fn get_exchange_rate(currency_id: CurrencyId) -> Result<UnsignedFixedPoint, DispatchError> {
+			let result = Oracle::get_exchange_rate(currency_id)?;
+			Ok(result)
 		}
 	}
 

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -251,10 +251,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("foucoco"),
 	impl_name: create_runtime_str!("foucoco"),
 	authoring_version: 1,
-	spec_version: 1,
+	spec_version: 2,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 1,
+	transaction_version: 2,
 	state_version: 1,
 };
 

--- a/runtime/pendulum/Cargo.toml
+++ b/runtime/pendulum/Cargo.toml
@@ -26,7 +26,7 @@ smallvec = "1.9.0"
 runtime-common = {path = "../common", default-features = false}
 
 # Spacewalk libraries
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev =  "31df1832483199b978ae07f6ed4e018a11ff4dba"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
 
 # Substrate
 frame-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40"}


### PR DESCRIPTION
<!-- If you added changes to files in the `node` directory or any other changes that would require a re-deployment of the collator nodes, please add the following line to the PR description: 
-->
This PR updates the Spacewalk dependencies to the latest commit on the main branch `468ec562bcee16257335b0ba488c4024983af1c5`. This includes the fixes for the Spacewalk testnet issues but not yet the new rewards implementation.

@pendulum-chain/product: This PR adds changes to the node client code that require a **redeployment of the collator nodes** to take effect.  Please ensure that the collator nodes are redeployed after this PR is merged.  
The change that requires a redeployment of the collator nodes is [this](https://github.com/pendulum-chain/spacewalk/pull/402) one.

Compiled foucoco-runtime binary: 
[foucoco_runtime.compact.compressed.wasm.zip](https://github.com/pendulum-chain/pendulum/files/12915233/foucoco_runtime.compact.compressed.wasm.zip)


<!-- Replace xx with the issue number that is fixed by this pull request. -->
Closes #322. 

