### PR TITLE
329 update spacewalk dependencies and bump spec version for amplitude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 [[package]]
 name = "clients-info"
 version = "0.1.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "currency"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2848,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "fee"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "issue"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -5422,7 +5422,7 @@ dependencies = [
 [[package]]
 name = "module-issue-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "jsonrpsee",
  "module-issue-rpc-runtime-api",
@@ -5435,7 +5435,7 @@ dependencies = [
 [[package]]
 name = "module-issue-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5446,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "module-oracle-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5460,7 +5460,7 @@ dependencies = [
 [[package]]
 name = "module-oracle-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5473,7 +5473,7 @@ dependencies = [
 [[package]]
 name = "module-redeem-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "jsonrpsee",
  "module-redeem-rpc-runtime-api",
@@ -5486,7 +5486,7 @@ dependencies = [
 [[package]]
 name = "module-redeem-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5497,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "module-replace-rpc"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "jsonrpsee",
  "module-replace-rpc-runtime-api",
@@ -5510,7 +5510,7 @@ dependencies = [
 [[package]]
 name = "module-replace-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5521,7 +5521,7 @@ dependencies = [
 [[package]]
 name = "module-vault-registry-rpc"
 version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5535,7 +5535,7 @@ dependencies = [
 [[package]]
 name = "module-vault-registry-rpc-runtime-api"
 version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "frame-support",
  "module-oracle-rpc-runtime-api",
@@ -5810,7 +5810,7 @@ dependencies = [
 [[package]]
 name = "nomination"
 version = "0.5.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "currency",
  "fee",
@@ -5981,7 +5981,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "oracle"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "currency",
  "dia-oracle",
@@ -9504,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "redeem"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "currency",
  "fee",
@@ -9665,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "replace"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "currency",
  "fee",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reward"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11453,7 +11453,7 @@ dependencies = [
 [[package]]
 name = "security"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12495,7 +12495,7 @@ dependencies = [
 [[package]]
 name = "spacewalk-primitives"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "base58",
  "bstringify",
@@ -12559,7 +12559,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staking"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12765,7 +12765,7 @@ dependencies = [
 [[package]]
 name = "stellar-relay"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -13744,7 +13744,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 [[package]]
 name = "vault-registry"
 version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=468ec562bcee16257335b0ba488c4024983af1c5#468ec562bcee16257335b0ba488c4024983af1c5"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
 dependencies = [
  "currency",
  "fee",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,13 +15,13 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.145", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 
-module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "58983d2695c309665c9c017a022436aaee088f3d"}
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev = "58983d2695c309665c9c017a022436aaee088f3d"}
 
 # Local
 amplitude-runtime = {path = "../runtime/amplitude"}

--- a/runtime/amplitude/Cargo.toml
+++ b/runtime/amplitude/Cargo.toml
@@ -26,25 +26,25 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # Custom libraries for Spacewalk
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -240,10 +240,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("amplitude"),
 	impl_name: create_runtime_str!("amplitude"),
 	authoring_version: 1,
-	spec_version: 10,
+	spec_version: 11,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 10,
+	transaction_version: 11,
 	state_version: 1,
 };
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -30,7 +30,7 @@ orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-m
 dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.40" }
 zenlink-protocol = { git = "https://github.com/pendulum-chain/Zenlink-DEX-Module", default-features = false, branch = "polkadot-v0.9.40-protocol" }
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
 
 [features]
 default = [

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -26,26 +26,26 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # custom libraries from spacewalk
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
 
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }

--- a/runtime/pendulum/Cargo.toml
+++ b/runtime/pendulum/Cargo.toml
@@ -26,7 +26,7 @@ smallvec = "1.9.0"
 runtime-common = {path = "../common", default-features = false}
 
 # Spacewalk libraries
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "468ec562bcee16257335b0ba488c4024983af1c5"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
 
 # Substrate
 frame-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40"}


### PR DESCRIPTION
<!-- If you added changes to files in the `node` directory or any other changes that would require a re-deployment of the collator nodes, please add the following line to the PR description:
@pendulum-chain/product: This PR adds changes to the node client code that require a **redeployment of the collator nodes** to take effect. 
Please ensure that the collator nodes are redeployed after this PR is merged.  
-->

This is preparing the Amplitude runtime for the next runtime upgrade. 

The compiled binary of the amplitude runtime is attached.
[amplitude_runtime.compact.compressed.wasm.zip](https://github.com/pendulum-chain/pendulum/files/13073641/amplitude_runtime.compact.compressed.wasm.zip)


<!-- Replace xx with the issue number that is fixed by this pull request. -->
Closes #329. 