### PR TITLE
add new reward/reward-distribution pallets to foucoco and amplitude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,9 +254,10 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain",
  "polkadot-runtime-common",
+ "pooled-rewards",
  "redeem",
  "replace",
- "reward",
+ "reward-distribution",
  "runtime-common",
  "scale-info",
  "security",
@@ -1188,8 +1189,8 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clients-info"
-version = "0.1.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2059,8 +2060,8 @@ dependencies = [
 
 [[package]]
 name = "currency"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2848,15 +2849,17 @@ dependencies = [
 [[package]]
 name = "fee"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "currency",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "oracle",
  "pallet-balances",
  "parity-scale-codec",
- "reward",
+ "pooled-rewards",
+ "reward-distribution",
  "scale-info",
  "security",
  "serde",
@@ -3065,9 +3068,10 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain",
  "polkadot-runtime-common",
+ "pooled-rewards",
  "redeem",
  "replace",
- "reward",
+ "reward-distribution",
  "runtime-common",
  "scale-info",
  "security",
@@ -4145,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "issue"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -4162,6 +4166,8 @@ dependencies = [
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
+ "pooled-rewards",
+ "reward-distribution",
  "scale-info",
  "security",
  "serde",
@@ -5421,8 +5427,8 @@ dependencies = [
 
 [[package]]
 name = "module-issue-rpc"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "jsonrpsee",
  "module-issue-rpc-runtime-api",
@@ -5434,8 +5440,8 @@ dependencies = [
 
 [[package]]
 name = "module-issue-rpc-runtime-api"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5445,8 +5451,8 @@ dependencies = [
 
 [[package]]
 name = "module-oracle-rpc"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5459,8 +5465,8 @@ dependencies = [
 
 [[package]]
 name = "module-oracle-rpc-runtime-api"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5472,8 +5478,8 @@ dependencies = [
 
 [[package]]
 name = "module-redeem-rpc"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "jsonrpsee",
  "module-redeem-rpc-runtime-api",
@@ -5485,8 +5491,8 @@ dependencies = [
 
 [[package]]
 name = "module-redeem-rpc-runtime-api"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5496,8 +5502,8 @@ dependencies = [
 
 [[package]]
 name = "module-replace-rpc"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "jsonrpsee",
  "module-replace-rpc-runtime-api",
@@ -5509,8 +5515,8 @@ dependencies = [
 
 [[package]]
 name = "module-replace-rpc-runtime-api"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5520,8 +5526,8 @@ dependencies = [
 
 [[package]]
 name = "module-vault-registry-rpc"
-version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5534,8 +5540,8 @@ dependencies = [
 
 [[package]]
 name = "module-vault-registry-rpc-runtime-api"
-version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "frame-support",
  "module-oracle-rpc-runtime-api",
@@ -5809,8 +5815,8 @@ dependencies = [
 
 [[package]]
 name = "nomination"
-version = "0.5.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "currency",
  "fee",
@@ -5824,7 +5830,8 @@ dependencies = [
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
- "reward",
+ "pooled-rewards",
+ "reward-distribution",
  "scale-info",
  "security",
  "serde",
@@ -5980,8 +5987,8 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "oracle"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "currency",
  "dia-oracle",
@@ -9078,6 +9085,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pooled-rewards"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
+dependencies = [
+ "currency",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "spacewalk-primitives",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9504,7 +9532,7 @@ dependencies = [
 [[package]]
 name = "redeem"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "currency",
  "fee",
@@ -9519,6 +9547,7 @@ dependencies = [
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
+ "reward-distribution",
  "scale-info",
  "security",
  "serde",
@@ -9665,7 +9694,7 @@ dependencies = [
 [[package]]
 name = "replace"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "currency",
  "fee",
@@ -9681,6 +9710,8 @@ dependencies = [
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
+ "pooled-rewards",
+ "reward-distribution",
  "scale-info",
  "security",
  "serde",
@@ -9707,7 +9738,7 @@ dependencies = [
 [[package]]
 name = "reward"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9721,6 +9752,35 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "spacewalk-primitives",
+]
+
+[[package]]
+name = "reward-distribution"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
+dependencies = [
+ "currency",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "oracle",
+ "orml-currencies",
+ "orml-tokens",
+ "orml-traits",
+ "pallet-balances",
+ "parity-scale-codec",
+ "pooled-rewards",
+ "scale-info",
+ "security",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "spacewalk-primitives",
+ "staking",
 ]
 
 [[package]]
@@ -11452,8 +11512,8 @@ dependencies = [
 
 [[package]]
 name = "security"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12494,8 +12554,8 @@ dependencies = [
 
 [[package]]
 name = "spacewalk-primitives"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "base58",
  "bstringify",
@@ -12559,7 +12619,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staking"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12765,7 +12825,7 @@ dependencies = [
 [[package]]
 name = "stellar-relay"
 version = "1.0.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -13743,8 +13803,8 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vault-registry"
-version = "1.2.0"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=58983d2695c309665c9c017a022436aaee088f3d#58983d2695c309665c9c017a022436aaee088f3d"
+version = "1.0.0"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e5c6acdfdc2482183ad064d1a27f75b61adf2546#e5c6acdfdc2482183ad064d1a27f75b61adf2546"
 dependencies = [
  "currency",
  "fee",
@@ -13760,7 +13820,9 @@ dependencies = [
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
+ "pooled-rewards",
  "reward",
+ "reward-distribution",
  "scale-info",
  "security",
  "serde",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,13 +15,13 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.145", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 
-module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
 
 # Local
 amplitude-runtime = {path = "../runtime/amplitude"}

--- a/runtime/amplitude/Cargo.toml
+++ b/runtime/amplitude/Cargo.toml
@@ -26,25 +26,27 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # Custom libraries for Spacewalk
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
+pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
@@ -179,6 +181,7 @@ std = [
     "pallet-transaction-payment-rpc-runtime-api/std",
     "pallet-transaction-payment/std",
     "pallet-treasury/std",
+    "pooled-rewards/std",
     "pallet-utility/std",
     "pallet-vesting/std",
     "pallet-xcm/std",
@@ -212,7 +215,6 @@ std = [
     "staking/std",
     "oracle/std",
     "stellar-relay/std",
-    "reward/std",
     "fee/std",
     "vault-registry/std",
     "redeem/std",

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -358,7 +358,7 @@ impl Contains<RuntimeCall> for BaseFilter {
 			RuntimeCall::Security(_) |
 			RuntimeCall::StellarRelay(_) |
 			RuntimeCall::VaultRegistry(_) |
-			RuntimeCall::VaultRewards(_) |
+			RuntimeCall::PooledVaultRewards(_) |
 			RuntimeCall::Farming(_) |
 			RuntimeCall::AssetRegistry(_) |
 			RuntimeCall::RewardDistribution(_)=> true,
@@ -1152,7 +1152,7 @@ impl fee::Config for Runtime {
 	type SignedInner = SignedInner;
 	type UnsignedFixedPoint = UnsignedFixedPoint;
 	type UnsignedInner = UnsignedInner;
-	type VaultRewards = VaultRewards;
+	type VaultRewards = PooledVaultRewards;
 	type VaultStaking = VaultStaking;
 	type OnSweep = currency::SweepFunds<Runtime, FeeAccount>;
 	type MaxExpectedValue = MaxExpectedValue;
@@ -1202,7 +1202,9 @@ impl clients_info::Config for Runtime {
 	type MaxNameLength = ConstU32<255>;
 	type MaxUriLength = ConstU32<255>;
 }
-
+// Choice of parameters: Perquintill::from_parts(37567400000000000u64) represents a value of
+// 0.0375674 = 37567400000000000 / 1×10¹⁸
+// The decay interval 216000 equates to a month when considering 1 block every 12 seconds
 parameter_types! {
 	pub const DecayRate: Perquintill = Perquintill::from_parts(37567400000000000u64);
 	pub const MaxCurrencies: u32 = 10;
@@ -1214,7 +1216,7 @@ impl reward_distribution::Config for Runtime {
 	type Balance = Balance;
 	type DecayInterval = ConstU32<216_000>;
 	type DecayRate = DecayRate;
-	type VaultRewards = VaultRewards;
+	type VaultRewards = PooledVaultRewards;
 	type MaxCurrencies = MaxCurrencies;
 	type OracleApi = Oracle;
 	type Balances = Balances;
@@ -1318,7 +1320,7 @@ construct_runtime!(
 		Security: security::{Pallet, Call, Config, Storage, Event<T>} = 67,
 		StellarRelay: stellar_relay::{Pallet, Call, Config<T>, Storage, Event<T>} = 68,
 		VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>, ValidateUnsigned} = 69,
-		VaultRewards: pooled_rewards::{Pallet, Call, Storage, Event<T>} = 70,
+		PooledVaultRewards: pooled_rewards::{Pallet, Call, Storage, Event<T>} = 70,
 		VaultStaking: staking::{Pallet, Storage, Event<T>} = 71,
 		ClientsInfo: clients_info::{Pallet, Call, Storage, Event<T>} = 72,
 		RewardDistribution: reward_distribution::{Pallet, Call, Storage, Event<T>} = 73,

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1204,7 +1204,7 @@ impl clients_info::Config for Runtime {
 }
 
 parameter_types! {
-	pub const DecayRate: Perquintill = Perquintill::from_percent(5);
+	pub const DecayRate: Perquintill = Perquintill::from_parts(37567400000000000u64);
 	pub const MaxCurrencies: u32 = 10;
 }
 
@@ -1212,7 +1212,7 @@ impl reward_distribution::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = reward_distribution::SubstrateWeight<Runtime>;
 	type Balance = Balance;
-	type DecayInterval = ConstU32<100>;
+	type DecayInterval = ConstU32<216_000>;
 	type DecayRate = DecayRate;
 	type VaultRewards = VaultRewards;
 	type MaxCurrencies = MaxCurrencies;

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -360,7 +360,8 @@ impl Contains<RuntimeCall> for BaseFilter {
 			RuntimeCall::VaultRegistry(_) |
 			RuntimeCall::VaultRewards(_) |
 			RuntimeCall::Farming(_) |
-			RuntimeCall::AssetRegistry(_) => true,
+			RuntimeCall::AssetRegistry(_) |
+			RuntimeCall::RewardDistribution(_)=> true,
 			// All pallets are allowed, but exhaustive match is defensive
 			// in the case of adding new pallets.
 		}
@@ -1079,12 +1080,18 @@ impl security::Config for Runtime {
 	type WeightInfo = security::SubstrateWeight<Runtime>;
 }
 
+parameter_types! {
+	pub const MaxRewardCurrencies: u32= 10;
+}
+
+
 impl staking::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type SignedInner = SignedInner;
 	type SignedFixedPoint = SignedFixedPoint;
 	type GetNativeCurrencyId = NativeCurrencyId;
 	type CurrencyId = CurrencyId;
+	type MaxRewardCurrencies = MaxRewardCurrencies;
 }
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -1131,13 +1138,7 @@ impl stellar_relay::Config for Runtime {
 	type WeightInfo = stellar_relay::SubstrateWeight<Runtime>;
 }
 
-impl reward::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type SignedFixedPoint = SignedFixedPoint;
-	type RewardId = VaultId;
-	type CurrencyId = CurrencyId;
-	type GetNativeCurrencyId = NativeCurrencyId;
-}
+
 parameter_types! {
 	pub const FeePalletId: PalletId = PalletId(*b"mod/fees");
 	pub const VaultRegistryPalletId: PalletId = PalletId(*b"mod/vreg");
@@ -1155,6 +1156,7 @@ impl fee::Config for Runtime {
 	type VaultStaking = VaultStaking;
 	type OnSweep = currency::SweepFunds<Runtime, FeeAccount>;
 	type MaxExpectedValue = MaxExpectedValue;
+	type RewardDistribution = RewardDistribution;
 }
 
 impl vault_registry::Config for Runtime {
@@ -1199,6 +1201,35 @@ impl clients_info::Config for Runtime {
 	type WeightInfo = clients_info::SubstrateWeight<Runtime>;
 	type MaxNameLength = ConstU32<255>;
 	type MaxUriLength = ConstU32<255>;
+}
+
+parameter_types! {
+	pub const DecayRate: Perquintill = Perquintill::from_percent(5);
+	pub const MaxCurrencies: u32 = 10;
+}
+
+impl reward_distribution::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = reward_distribution::SubstrateWeight<Runtime>;
+	type Balance = Balance;
+	type DecayInterval = ConstU32<100>;
+	type DecayRate = DecayRate;
+	type VaultRewards = VaultRewards;
+	type MaxCurrencies = MaxCurrencies;
+	type OracleApi = Oracle;
+	type Balances = Balances;
+	type VaultStaking = VaultStaking;
+	type FeePalletId = FeePalletId;
+}
+
+
+impl pooled_rewards::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type SignedFixedPoint = SignedFixedPoint;
+	type PoolId = CurrencyId;
+	type PoolRewardsCurrencyId = CurrencyId;
+	type StakeId = VaultId;
+	type MaxRewardCurrencies = MaxRewardCurrencies;
 }
 
 parameter_types! {
@@ -1287,9 +1318,10 @@ construct_runtime!(
 		Security: security::{Pallet, Call, Config, Storage, Event<T>} = 67,
 		StellarRelay: stellar_relay::{Pallet, Call, Config<T>, Storage, Event<T>} = 68,
 		VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>, ValidateUnsigned} = 69,
-		VaultRewards: reward::{Pallet, Call, Storage, Event<T>} = 70,
+		VaultRewards: pooled_rewards::{Pallet, Call, Storage, Event<T>} = 70,
 		VaultStaking: staking::{Pallet, Storage, Event<T>} = 71,
 		ClientsInfo: clients_info::{Pallet, Call, Storage, Event<T>} = 72,
+		RewardDistribution: reward_distribution::{Pallet, Call, Storage, Event<T>} = 73,
 
 		Farming: farming::{Pallet, Call, Storage, Event<T>} = 90,
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -30,7 +30,7 @@ orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-m
 dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.40" }
 zenlink-protocol = { git = "https://github.com/pendulum-chain/Zenlink-DEX-Module", default-features = false, branch = "polkadot-v0.9.40-protocol" }
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546" }
 
 [features]
 default = [

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -26,26 +26,27 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # custom libraries from spacewalk
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-reward = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
 
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
@@ -188,6 +189,7 @@ std = [
     "parachain-info/std",
     "parachain-staking/std",
     "orml-currencies-allowance-extension/std",
+    "pooled-rewards/std",
     "polkadot-parachain/std",
     "polkadot-runtime-common/std",
     "runtime-common/std",
@@ -214,7 +216,6 @@ std = [
     "staking/std",
     "oracle/std",
     "stellar-relay/std",
-    "reward/std",
     "fee/std",
     "vault-registry/std",
     "redeem/std",

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -368,7 +368,7 @@ impl Contains<RuntimeCall> for BaseFilter {
 			RuntimeCall::Security(_) |
 			RuntimeCall::StellarRelay(_) |
 			RuntimeCall::VaultRegistry(_) |
-			RuntimeCall::VaultRewards(_) |
+			RuntimeCall::PooledVaultRewards(_) |
 			RuntimeCall::Farming(_) |
 			RuntimeCall::TokenAllowance(_) |
 			RuntimeCall::AssetRegistry(_) |
@@ -1460,7 +1460,7 @@ impl fee::Config for Runtime {
 	type SignedInner = SignedInner;
 	type UnsignedFixedPoint = UnsignedFixedPoint;
 	type UnsignedInner = UnsignedInner;
-	type VaultRewards = VaultRewards;
+	type VaultRewards = PooledVaultRewards;
 	type VaultStaking = VaultStaking;
 	type OnSweep = currency::SweepFunds<Runtime, FeeAccount>;
 	type MaxExpectedValue = MaxExpectedValue;
@@ -1510,7 +1510,9 @@ impl clients_info::Config for Runtime {
 	type MaxNameLength = ConstU32<255>;
 	type MaxUriLength = ConstU32<255>;
 }
-
+// Choice of parameters: Perquintill::from_parts(37567400000000000u64) represents a value of
+// 0.0375674 = 37567400000000000 / 1×10¹⁸
+// The decay interval 216000 equates to a month when considering 1 block every 12 seconds
 parameter_types! {
 	pub const DecayRate: Perquintill = Perquintill::from_parts(37567400000000000u64);
 	pub const MaxCurrencies: u32 = 10;
@@ -1522,7 +1524,7 @@ impl reward_distribution::Config for Runtime {
 	type Balance = Balance;
 	type DecayInterval = ConstU32<216_000>;
 	type DecayRate = DecayRate;
-	type VaultRewards = VaultRewards;
+	type VaultRewards = PooledVaultRewards;
 	type MaxCurrencies = MaxCurrencies;
 	type OracleApi = Oracle;
 	type Balances = Balances;
@@ -1618,7 +1620,7 @@ construct_runtime!(
 		Security: security::{Pallet, Call, Config, Storage, Event<T>} = 67,
 		StellarRelay: stellar_relay::{Pallet, Call, Config<T>, Storage, Event<T>} = 68,
 		VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>, ValidateUnsigned} = 69,
-		VaultRewards: pooled_rewards::{Pallet, Call, Storage, Event<T>} = 70,
+		PooledVaultRewards: pooled_rewards::{Pallet, Call, Storage, Event<T>} = 70,
 		VaultStaking: staking::{Pallet, Storage, Event<T>} = 71,
 		ClientsInfo: clients_info::{Pallet, Call, Storage, Event<T>} = 72,
 		RewardDistribution: reward_distribution::{Pallet, Call, Storage, Event<T>} = 73,

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1512,7 +1512,7 @@ impl clients_info::Config for Runtime {
 }
 
 parameter_types! {
-	pub const DecayRate: Perquintill = Perquintill::from_percent(5);
+	pub const DecayRate: Perquintill = Perquintill::from_parts(37567400000000000u64);
 	pub const MaxCurrencies: u32 = 10;
 }
 
@@ -1520,7 +1520,7 @@ impl reward_distribution::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = reward_distribution::SubstrateWeight<Runtime>;
 	type Balance = Balance;
-	type DecayInterval = ConstU32<100>;
+	type DecayInterval = ConstU32<216_000>;
 	type DecayRate = DecayRate;
 	type VaultRewards = VaultRewards;
 	type MaxCurrencies = MaxCurrencies;

--- a/runtime/pendulum/Cargo.toml
+++ b/runtime/pendulum/Cargo.toml
@@ -26,7 +26,7 @@ smallvec = "1.9.0"
 runtime-common = {path = "../common", default-features = false}
 
 # Spacewalk libraries
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "58983d2695c309665c9c017a022436aaee088f3d"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "e5c6acdfdc2482183ad064d1a27f75b61adf2546"}
 
 # Substrate
 frame-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40"}


### PR DESCRIPTION
Closes #314. 

Adds the new `pooled-reward` and `reward-distribution` pallets to Foucoco and Amplitude runtimes.

As was discussed previously in [the implementation](https://github.com/pendulum-chain/spacewalk/pull/415), `PoolId` is set to `CurrencyId` and `StakeId` is set to `VaultId`

For now the new value of `MaxRewardCurrencies` of the staking pallet is set to 10. 