### PR TITLE
Prepare Foucoco runtime upgrade to spec version 3

### DIFF
--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -251,10 +251,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("foucoco"),
 	impl_name: create_runtime_str!("foucoco"),
 	authoring_version: 1,
-	spec_version: 2,
+	spec_version: 3,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 2,
+	transaction_version: 3,
 	state_version: 1,
 };
 


### PR DESCRIPTION
Closes #336 

WASM file used for the upgrade:
[foucoco_runtime.compact.compressed.wasm.zip](https://github.com/pendulum-chain/pendulum/files/13283902/foucoco_runtime.compact.compressed.wasm.zip)
