### PR TITLE
Bump spec and transaction version for amplitude

### DIFF
--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -241,10 +241,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("amplitude"),
 	impl_name: create_runtime_str!("amplitude"),
 	authoring_version: 1,
-	spec_version: 11,
+	spec_version: 12,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 11,
+	transaction_version: 12,
 	state_version: 1,
 };
 


### PR DESCRIPTION
<!-- If you added changes to files in the `node` directory or any other changes that would require a re-deployment of the collator nodes, please add the following line to the PR description:
@pendulum-chain/product: This PR adds changes to the node client code that require a **redeployment of the collator nodes** to take effect. 
Please ensure that the collator nodes are redeployed after this PR is merged.  
-->

This only bumps the transaction and spec version. No dependency updates are needed for Spacewalk because they were already updated in #362. 

<!-- Replace xx with the issue number that is fixed by this pull request. -->
Closes #363. 

## Notes

- I tested running the new amplitude runtime locally using Zombienet. It produces blocks.
- I did not test the whole runtime upgrade in chopsticks, however.
- The latest compiled runtime binary contained in this branch is here: 
[amplitude_runtime.compact.compressed.wasm.zip](https://github.com/pendulum-chain/pendulum/files/13544228/amplitude_runtime.compact.compressed.wasm.zip)

