### PR TITLE
Add fee for incoming assets

### DIFF
--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -776,8 +776,14 @@ impl pallet_child_bounties::Config for Runtime {
 }
 
 parameter_type_with_key! {
-	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
-		NANOUNIT
+	pub ExistentialDeposits: |currency_id: CurrencyId| -> Balance {
+		// Since the xcm trader uses Tokens to get the minimum
+		// balance of both it's assets and native, we need to 
+		// handle native here
+		match currency_id{
+			CurrencyId::Native => EXISTENTIAL_DEPOSIT,
+			_ => NANOUNIT
+		}
 	};
 }
 

--- a/runtime/amplitude/src/xcm_config.rs
+++ b/runtime/amplitude/src/xcm_config.rs
@@ -12,15 +12,14 @@ use orml_traits::{
 use orml_xcm_support::{DepositToAlternative, IsNativeConcrete, MultiCurrencyAdapter};
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
-use polkadot_runtime_common::impls::ToAuthor;
 use sp_runtime::traits::Convert;
 use xcm::latest::{prelude::*, Weight as XCMWeight};
 use xcm_builder::{
 	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, ConvertedConcreteId, EnsureXcmOrigin,
-	FixedWeightBounds, FungiblesAdapter, NoChecking, ParentIsPreset, RelayChainAsNative,
-	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
+	FixedWeightBounds, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
+	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
+	SovereignSignedViaLocation, TakeWeightCredit,
 };
 use xcm_executor::{
 	traits::{JustTry, ShouldExecute},
@@ -44,7 +43,7 @@ use crate::{
 use super::{
 	AccountId, AmplitudeTreasuryAccount, Balance, Balances, Currencies, CurrencyId, ParachainInfo,
 	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Tokens,
-	Treasury, WeightToFee, XcmpQueue,
+	WeightToFee, XcmpQueue,
 };
 
 parameter_types! {

--- a/runtime/amplitude/src/xcm_config.rs
+++ b/runtime/amplitude/src/xcm_config.rs
@@ -135,11 +135,11 @@ impl RelayRelativeValue {
 	fn get_relative_value(id: CurrencyId) -> Option<RelativeValue> {
 		match id {
 			CurrencyId::XCM(index) => match index {
-				xcm_assets::RELAY_KSM => Some(RelativeValue { num: 1, denominator: 1 }),
-				xcm_assets::ASSETHUB_USDT => Some(RelativeValue { num: 1, denominator: 4 }),
+				xcm_assets::RELAY_KSM => Some(RelativeValue { num: 100, denominator: 1 }),
+				xcm_assets::ASSETHUB_USDT => Some(RelativeValue { num: 20, denominator: 4 }),
 				_ => None,
 			},
-			CurrencyId::Native => Some(RelativeValue { num: 1, denominator: 2 }),
+			CurrencyId::Native => Some(RelativeValue { num: 1, denominator: 1 }),
 			_ => Some(RelativeValue { num: 1, denominator: 1 }),
 		}
 	}

--- a/runtime/amplitude/src/xcm_config.rs
+++ b/runtime/amplitude/src/xcm_config.rs
@@ -1,4 +1,3 @@
-
 use core::marker::PhantomData;
 
 use frame_support::{
@@ -47,7 +46,6 @@ use super::{
 	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Tokens,
 	Treasury, WeightToFee, XcmpQueue,
 };
-
 
 parameter_types! {
 	pub const RelayLocation: MultiLocation = MultiLocation::parent();
@@ -147,7 +145,6 @@ impl RelayRelativeValue {
 		}
 	}
 }
-
 
 /// Convert an incoming `MultiLocation` into a `CurrencyId` if possible.
 /// Here we need to know the canonical representation of all the tokens we handle in order to

--- a/runtime/amplitude/src/xcm_config.rs
+++ b/runtime/amplitude/src/xcm_config.rs
@@ -1,16 +1,4 @@
-use super::{
-	AccountId, AmplitudeTreasuryAccount, Balance, Balances, Currencies, CurrencyId, ParachainInfo,
-	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Tokens,
-	Treasury, WeightToFee, XcmpQueue,
-};
 
-use crate::{
-	assets::{
-		native_locations::{native_location_external_pov, native_location_local_pov},
-		xcm_assets,
-	},
-	ConstU32,
-};
 use core::marker::PhantomData;
 
 use frame_support::{
@@ -44,6 +32,20 @@ use runtime_common::parachains::kusama::asset_hub;
 
 use cumulus_primitives_utility::{
 	ChargeWeightInFungibles, TakeFirstAssetTrader, XcmFeesTo32ByteAccount,
+};
+
+use super::{
+	AccountId, AmplitudeTreasuryAccount, Balance, Balances, Currencies, CurrencyId, ParachainInfo,
+	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Tokens,
+	Treasury, WeightToFee, XcmpQueue,
+};
+
+use crate::{
+	assets::{
+		native_locations::{native_location_external_pov, native_location_local_pov},
+		xcm_assets,
+	},
+	ConstU32,
 };
 
 parameter_types! {

--- a/runtime/common/src/custom_transactor.rs
+++ b/runtime/common/src/custom_transactor.rs
@@ -1,21 +1,7 @@
-use sp_runtime::{
-	codec::FullCodec,
-	traits::{Convert, MaybeSerializeDeserialize, SaturatedConversion},
-};
-use sp_std::{
-	cmp::{Eq, PartialEq},
-	fmt::Debug,
-	marker::PhantomData,
-	prelude::*,
-	result,
-};
+use sp_std::{marker::PhantomData, result};
 
-use orml_xcm_support::{OnDepositFail, UnknownAsset as UnknownAssetT};
 use xcm::v3::{prelude::*, Error as XcmError, MultiAsset, MultiLocation, Result};
-use xcm_executor::{
-	traits::{Convert as MoreConvert, MatchesFungible, TransactAsset},
-	Assets,
-};
+use xcm_executor::{traits::TransactAsset, Assets};
 
 pub struct AssetData {
 	pub length: u8,

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -781,8 +781,14 @@ impl pallet_child_bounties::Config for Runtime {
 }
 
 parameter_type_with_key! {
-	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
-		NANOUNIT
+	pub ExistentialDeposits: |currency_id: CurrencyId| -> Balance {
+		// Since the xcm trader uses Tokens to get the minimum
+		// balance of both it's assets and native, we need to 
+		// handle native here
+		match currency_id{
+			CurrencyId::Native => EXISTENTIAL_DEPOSIT,
+			_ => NANOUNIT
+		}
 	};
 }
 

--- a/runtime/integration-tests/src/amplitude_tests.rs
+++ b/runtime/integration-tests/src/amplitude_tests.rs
@@ -7,7 +7,6 @@ use crate::{
 		parachain1_transfer_incorrect_asset_to_parachain2_should_fail,
 		transfer_10_relay_token_from_parachain_to_relay_chain,
 		transfer_20_relay_token_from_relay_chain_to_parachain,
-		transfer_foreign_token_from_external_parachain_to_us_and_check_fees,
 		transfer_native_token_from_parachain1_to_parachain2_and_back,
 	},
 	AMPLITUDE_ID, ASSETHUB_ID, SIBLING_ID,
@@ -19,6 +18,8 @@ use xcm::latest::NetworkId;
 use xcm_emulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain, TestExt};
 
 const KSM_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 3200000000;
+const USDT_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 12800000000;
+const NATIVE_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 6400000000;
 
 decl_test_relay_chain! {
 	pub struct KusamaRelay {
@@ -69,91 +70,81 @@ decl_test_network! {
 	}
 }
 
-// #[test]
-// fn transfer_ksm_from_kusama_to_amplitude() {
-// 	transfer_20_relay_token_from_relay_chain_to_parachain!(
-// 		KusamaMockNet,
-// 		kusama_runtime,
-// 		KusamaRelay,
-// 		amplitude_runtime,
-// 		AmplitudeParachain,
-// 		AMPLITUDE_ID,
-// 		KSM_FEE_WHEN_TRANSFER_TO_PARACHAIN
-// 	);
-// }
+#[test]
+fn transfer_ksm_from_kusama_to_amplitude() {
+	transfer_20_relay_token_from_relay_chain_to_parachain!(
+		KusamaMockNet,
+		kusama_runtime,
+		KusamaRelay,
+		amplitude_runtime,
+		AmplitudeParachain,
+		AMPLITUDE_ID,
+		KSM_FEE_WHEN_TRANSFER_TO_PARACHAIN
+	);
+}
 
-// #[test]
-// fn transfer_ksm_from_amplitude_to_kusama() {
-// 	transfer_10_relay_token_from_parachain_to_relay_chain!(
-// 		KusamaMockNet,
-// 		kusama_runtime,
-// 		KusamaRelay,
-// 		amplitude_runtime,
-// 		AmplitudeParachain
-// 	);
-// }
+#[test]
+fn transfer_ksm_from_amplitude_to_kusama() {
+	transfer_10_relay_token_from_parachain_to_relay_chain!(
+		KusamaMockNet,
+		kusama_runtime,
+		KusamaRelay,
+		amplitude_runtime,
+		AmplitudeParachain
+	);
+}
 
-// #[test]
-// fn assethub_transfer_incorrect_asset_to_amplitude_should_fail() {
-// 	parachain1_transfer_incorrect_asset_to_parachain2_should_fail!(
-// 		kusama_asset_hub_runtime,
-// 		AssetHubParachain,
-// 		amplitude_runtime,
-// 		AmplitudeParachain,
-// 		AMPLITUDE_ID
-// 	);
-// }
+#[test]
+fn assethub_transfer_incorrect_asset_to_amplitude_should_fail() {
+	parachain1_transfer_incorrect_asset_to_parachain2_should_fail!(
+		kusama_asset_hub_runtime,
+		AssetHubParachain,
+		amplitude_runtime,
+		AmplitudeParachain,
+		AMPLITUDE_ID
+	);
+}
 
-// #[test]
-// fn assethub_transfer_asset_to_amplitude() {
-// 	parachain1_transfer_asset_to_parachain2!(
-// 		kusama_asset_hub_runtime,
-// 		AssetHubParachain,
-// 		USDT_ASSET_ID,
-// 		amplitude_runtime,
-// 		AmplitudeParachain,
-// 		AMPLITUDE_ID
-// 	);
-// }
+#[test]
+fn assethub_transfer_asset_to_amplitude() {
+	parachain1_transfer_asset_to_parachain2!(
+		kusama_asset_hub_runtime,
+		AssetHubParachain,
+		USDT_ASSET_ID,
+		amplitude_runtime,
+		AmplitudeParachain,
+		AMPLITUDE_ID,
+		USDT_FEE_WHEN_TRANSFER_TO_PARACHAIN
+	);
+}
 
-// #[test]
-// fn assethub_transfer_asset_to_amplitude_and_back() {
-// 	let network_id = NetworkId::Kusama;
+#[test]
+fn assethub_transfer_asset_to_amplitude_and_back() {
+	let network_id = NetworkId::Kusama;
 
-// 	parachain1_transfer_asset_to_parachain2_and_back!(
-// 		kusama_asset_hub_runtime,
-// 		AssetHubParachain,
-// 		ASSETHUB_ID,
-// 		USDT_ASSET_ID,
-// 		amplitude_runtime,
-// 		AmplitudeParachain,
-// 		AMPLITUDE_ID,
-// 		network_id
-// 	);
-// }
+	parachain1_transfer_asset_to_parachain2_and_back!(
+		kusama_asset_hub_runtime,
+		AssetHubParachain,
+		ASSETHUB_ID,
+		USDT_ASSET_ID,
+		amplitude_runtime,
+		AmplitudeParachain,
+		AMPLITUDE_ID,
+		network_id,
+		USDT_FEE_WHEN_TRANSFER_TO_PARACHAIN
+	);
+}
 
-// #[test]
-// fn transfer_native_token_from_amplitude_to_sibling_parachain_and_back() {
-// 	transfer_native_token_from_parachain1_to_parachain2_and_back!(
-// 		KusamaMockNet,
-// 		amplitude_runtime,
-// 		AmplitudeParachain,
-// 		sibling,
-// 		SiblingParachain,
-// 		AMPLITUDE_ID,
-// 		SIBLING_ID
-// 	);
-// }
-
-// #[test]
-// fn transfer_foreign_token_from_external_parachain_to_us_and_check_fees() {
-// 	transfer_foreign_token_from_external_parachain_to_us_and_check_fees!(
-// 		KusamaMockNet,
-// 		sibling,
-// 		SiblingParachain,
-// 		amplitude_runtime,
-// 		AmplitudeParachain,
-// 		SIBLING_ID,
-// 		AMPLITUDE_ID
-// 	);
-// }
+#[test]
+fn transfer_native_token_from_amplitude_to_sibling_parachain_and_back() {
+	transfer_native_token_from_parachain1_to_parachain2_and_back!(
+		KusamaMockNet,
+		amplitude_runtime,
+		AmplitudeParachain,
+		sibling,
+		SiblingParachain,
+		AMPLITUDE_ID,
+		SIBLING_ID,
+		NATIVE_FEE_WHEN_TRANSFER_TO_PARACHAIN
+	);
+}

--- a/runtime/integration-tests/src/amplitude_tests.rs
+++ b/runtime/integration-tests/src/amplitude_tests.rs
@@ -7,6 +7,7 @@ use crate::{
 		parachain1_transfer_incorrect_asset_to_parachain2_should_fail,
 		transfer_10_relay_token_from_parachain_to_relay_chain,
 		transfer_20_relay_token_from_relay_chain_to_parachain,
+		transfer_foreign_token_from_external_parachain_to_us_and_check_fees,
 		transfer_native_token_from_parachain1_to_parachain2_and_back,
 	},
 	AMPLITUDE_ID, ASSETHUB_ID, SIBLING_ID,
@@ -68,78 +69,91 @@ decl_test_network! {
 	}
 }
 
-#[test]
-fn transfer_ksm_from_kusama_to_amplitude() {
-	transfer_20_relay_token_from_relay_chain_to_parachain!(
-		KusamaMockNet,
-		kusama_runtime,
-		KusamaRelay,
-		amplitude_runtime,
-		AmplitudeParachain,
-		AMPLITUDE_ID,
-		KSM_FEE_WHEN_TRANSFER_TO_PARACHAIN
-	);
-}
+// #[test]
+// fn transfer_ksm_from_kusama_to_amplitude() {
+// 	transfer_20_relay_token_from_relay_chain_to_parachain!(
+// 		KusamaMockNet,
+// 		kusama_runtime,
+// 		KusamaRelay,
+// 		amplitude_runtime,
+// 		AmplitudeParachain,
+// 		AMPLITUDE_ID,
+// 		KSM_FEE_WHEN_TRANSFER_TO_PARACHAIN
+// 	);
+// }
 
-#[test]
-fn transfer_ksm_from_amplitude_to_kusama() {
-	transfer_10_relay_token_from_parachain_to_relay_chain!(
-		KusamaMockNet,
-		kusama_runtime,
-		KusamaRelay,
-		amplitude_runtime,
-		AmplitudeParachain
-	);
-}
+// #[test]
+// fn transfer_ksm_from_amplitude_to_kusama() {
+// 	transfer_10_relay_token_from_parachain_to_relay_chain!(
+// 		KusamaMockNet,
+// 		kusama_runtime,
+// 		KusamaRelay,
+// 		amplitude_runtime,
+// 		AmplitudeParachain
+// 	);
+// }
 
-#[test]
-fn assethub_transfer_incorrect_asset_to_amplitude_should_fail() {
-	parachain1_transfer_incorrect_asset_to_parachain2_should_fail!(
-		kusama_asset_hub_runtime,
-		AssetHubParachain,
-		amplitude_runtime,
-		AmplitudeParachain,
-		AMPLITUDE_ID
-	);
-}
+// #[test]
+// fn assethub_transfer_incorrect_asset_to_amplitude_should_fail() {
+// 	parachain1_transfer_incorrect_asset_to_parachain2_should_fail!(
+// 		kusama_asset_hub_runtime,
+// 		AssetHubParachain,
+// 		amplitude_runtime,
+// 		AmplitudeParachain,
+// 		AMPLITUDE_ID
+// 	);
+// }
 
-#[test]
-fn assethub_transfer_asset_to_amplitude() {
-	parachain1_transfer_asset_to_parachain2!(
-		kusama_asset_hub_runtime,
-		AssetHubParachain,
-		USDT_ASSET_ID,
-		amplitude_runtime,
-		AmplitudeParachain,
-		AMPLITUDE_ID
-	);
-}
+// #[test]
+// fn assethub_transfer_asset_to_amplitude() {
+// 	parachain1_transfer_asset_to_parachain2!(
+// 		kusama_asset_hub_runtime,
+// 		AssetHubParachain,
+// 		USDT_ASSET_ID,
+// 		amplitude_runtime,
+// 		AmplitudeParachain,
+// 		AMPLITUDE_ID
+// 	);
+// }
 
-#[test]
-fn assethub_transfer_asset_to_amplitude_and_back() {
-	let network_id = NetworkId::Kusama;
+// #[test]
+// fn assethub_transfer_asset_to_amplitude_and_back() {
+// 	let network_id = NetworkId::Kusama;
 
-	parachain1_transfer_asset_to_parachain2_and_back!(
-		kusama_asset_hub_runtime,
-		AssetHubParachain,
-		ASSETHUB_ID,
-		USDT_ASSET_ID,
-		amplitude_runtime,
-		AmplitudeParachain,
-		AMPLITUDE_ID,
-		network_id
-	);
-}
+// 	parachain1_transfer_asset_to_parachain2_and_back!(
+// 		kusama_asset_hub_runtime,
+// 		AssetHubParachain,
+// 		ASSETHUB_ID,
+// 		USDT_ASSET_ID,
+// 		amplitude_runtime,
+// 		AmplitudeParachain,
+// 		AMPLITUDE_ID,
+// 		network_id
+// 	);
+// }
 
-#[test]
-fn transfer_native_token_from_amplitude_to_sibling_parachain_and_back() {
-	transfer_native_token_from_parachain1_to_parachain2_and_back!(
-		KusamaMockNet,
-		amplitude_runtime,
-		AmplitudeParachain,
-		sibling,
-		SiblingParachain,
-		AMPLITUDE_ID,
-		SIBLING_ID
-	);
-}
+// #[test]
+// fn transfer_native_token_from_amplitude_to_sibling_parachain_and_back() {
+// 	transfer_native_token_from_parachain1_to_parachain2_and_back!(
+// 		KusamaMockNet,
+// 		amplitude_runtime,
+// 		AmplitudeParachain,
+// 		sibling,
+// 		SiblingParachain,
+// 		AMPLITUDE_ID,
+// 		SIBLING_ID
+// 	);
+// }
+
+// #[test]
+// fn transfer_foreign_token_from_external_parachain_to_us_and_check_fees() {
+// 	transfer_foreign_token_from_external_parachain_to_us_and_check_fees!(
+// 		KusamaMockNet,
+// 		sibling,
+// 		SiblingParachain,
+// 		amplitude_runtime,
+// 		AmplitudeParachain,
+// 		SIBLING_ID,
+// 		AMPLITUDE_ID
+// 	);
+// }

--- a/runtime/integration-tests/src/amplitude_tests.rs
+++ b/runtime/integration-tests/src/amplitude_tests.rs
@@ -16,9 +16,9 @@ use statemine_runtime as kusama_asset_hub_runtime;
 use xcm::latest::NetworkId;
 use xcm_emulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain, TestExt};
 
-const KSM_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 3200000000;
-const USDT_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 12800000000;
-const NATIVE_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 6400000000;
+const KSM_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 32000000;
+const USDT_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 640000000;
+const NATIVE_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 3200000000;
 
 decl_test_relay_chain! {
 	pub struct KusamaRelay {

--- a/runtime/integration-tests/src/amplitude_tests.rs
+++ b/runtime/integration-tests/src/amplitude_tests.rs
@@ -2,8 +2,7 @@ use crate::{
 	mock::{kusama_relay_ext, para_ext, ParachainType, USDT_ASSET_ID},
 	sibling,
 	test_macros::{
-		moonbeam_transfers_token_and_handle_automation, parachain1_transfer_asset_to_parachain2,
-		parachain1_transfer_asset_to_parachain2_and_back,
+		parachain1_transfer_asset_to_parachain2, parachain1_transfer_asset_to_parachain2_and_back,
 		parachain1_transfer_incorrect_asset_to_parachain2_should_fail,
 		transfer_10_relay_token_from_parachain_to_relay_chain,
 		transfer_20_relay_token_from_relay_chain_to_parachain,

--- a/runtime/integration-tests/src/pendulum_tests.rs
+++ b/runtime/integration-tests/src/pendulum_tests.rs
@@ -19,6 +19,9 @@ use xcm::latest::NetworkId;
 use xcm_emulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain, TestExt};
 
 const DOT_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 3200000000; //The fees that relay chain will charge when transfer DOT to parachain. sovereign account of some parachain will receive transfer_amount - DOT_FEE
+const MOONBEAM_BRZ_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 32000000000; //Fees that we will charge in incoming Moonbeam's BRZ. Depends on the RelativeValue struct implementation.
+const USDT_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 12800000000; 
+const NATIVE_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 6400000000; //Fees that we will charge in incoming Moonbeam's BRZ. Depends on the RelativeValue struct implementation.
 
 decl_test_relay_chain! {
 	pub struct PolkadotRelay {
@@ -80,81 +83,84 @@ decl_test_network! {
 	}
 }
 
-// #[test]
-// fn transfer_dot_from_polkadot_to_pendulum() {
-// 	transfer_20_relay_token_from_relay_chain_to_parachain!(
-// 		PolkadotMockNet,
-// 		polkadot_runtime,
-// 		PolkadotRelay,
-// 		pendulum_runtime,
-// 		PendulumParachain,
-// 		PENDULUM_ID,
-// 		DOT_FEE_WHEN_TRANSFER_TO_PARACHAIN
-// 	)
-// }
+#[test]
+fn transfer_dot_from_polkadot_to_pendulum() {
+	transfer_20_relay_token_from_relay_chain_to_parachain!(
+		PolkadotMockNet,
+		polkadot_runtime,
+		PolkadotRelay,
+		pendulum_runtime,
+		PendulumParachain,
+		PENDULUM_ID,
+		DOT_FEE_WHEN_TRANSFER_TO_PARACHAIN
+	)
+}
 
-// #[test]
-// fn transfer_dot_from_pendulum_to_polkadot() {
-// 	transfer_10_relay_token_from_parachain_to_relay_chain!(
-// 		PolkadotMockNet,
-// 		polkadot_runtime,
-// 		PolkadotRelay,
-// 		pendulum_runtime,
-// 		PendulumParachain
-// 	);
-// }
+#[test]
+fn transfer_dot_from_pendulum_to_polkadot() {
+	transfer_10_relay_token_from_parachain_to_relay_chain!(
+		PolkadotMockNet,
+		polkadot_runtime,
+		PolkadotRelay,
+		pendulum_runtime,
+		PendulumParachain
+	);
+}
 
-// #[test]
-// fn assethub_transfer_incorrect_asset_to_pendulum_should_fail() {
-// 	parachain1_transfer_incorrect_asset_to_parachain2_should_fail!(
-// 		polkadot_asset_hub_runtime,
-// 		AssetHubParachain,
-// 		pendulum_runtime,
-// 		PendulumParachain,
-// 		PENDULUM_ID
-// 	);
-// }
+#[test]
+fn assethub_transfer_incorrect_asset_to_pendulum_should_fail() {
+	parachain1_transfer_incorrect_asset_to_parachain2_should_fail!(
+		polkadot_asset_hub_runtime,
+		AssetHubParachain,
+		pendulum_runtime,
+		PendulumParachain,
+		PENDULUM_ID
+	);
+}
 
-// #[test]
-// fn assethub_transfer_asset_to_pendulum() {
-// 	parachain1_transfer_asset_to_parachain2!(
-// 		polkadot_asset_hub_runtime,
-// 		AssetHubParachain,
-// 		USDT_ASSET_ID,
-// 		pendulum_runtime,
-// 		PendulumParachain,
-// 		PENDULUM_ID
-// 	);
-// }
+#[test]
+fn assethub_transfer_asset_to_pendulum() {
+	parachain1_transfer_asset_to_parachain2!(
+		polkadot_asset_hub_runtime,
+		AssetHubParachain,
+		USDT_ASSET_ID,
+		pendulum_runtime,
+		PendulumParachain,
+		PENDULUM_ID,
+		USDT_FEE_WHEN_TRANSFER_TO_PARACHAIN
+	);
+}
 
-// #[test]
-// fn assethub_transfer_asset_to_pendulum_and_back() {
-// 	let network_id = NetworkId::Polkadot;
+#[test]
+fn assethub_transfer_asset_to_pendulum_and_back() {
+	let network_id = NetworkId::Polkadot;
 
-// 	parachain1_transfer_asset_to_parachain2_and_back!(
-// 		polkadot_asset_hub_runtime,
-// 		AssetHubParachain,
-// 		ASSETHUB_ID,
-// 		USDT_ASSET_ID,
-// 		pendulum_runtime,
-// 		PendulumParachain,
-// 		PENDULUM_ID,
-// 		network_id
-// 	);
-// }
+	parachain1_transfer_asset_to_parachain2_and_back!(
+		polkadot_asset_hub_runtime,
+		AssetHubParachain,
+		ASSETHUB_ID,
+		USDT_ASSET_ID,
+		pendulum_runtime,
+		PendulumParachain,
+		PENDULUM_ID,
+		network_id,
+		USDT_FEE_WHEN_TRANSFER_TO_PARACHAIN
+	);
+}
 
-// #[test]
-// fn transfer_native_token_from_pendulum_to_sibling_parachain_and_back() {
-// 	transfer_native_token_from_parachain1_to_parachain2_and_back!(
-// 		PolkadotMockNet,
-// 		pendulum_runtime,
-// 		PendulumParachain,
-// 		sibling,
-// 		SiblingParachain,
-// 		PENDULUM_ID,
-// 		SIBLING_ID
-// 	);
-// }
+#[test]
+fn transfer_native_token_from_pendulum_to_sibling_parachain_and_back() {
+	transfer_native_token_from_parachain1_to_parachain2_and_back!(
+		PolkadotMockNet,
+		pendulum_runtime,
+		PendulumParachain,
+		sibling,
+		SiblingParachain,
+		PENDULUM_ID,
+		SIBLING_ID,
+		NATIVE_FEE_WHEN_TRANSFER_TO_PARACHAIN
+	);
+}
 
 #[test]
 fn moonbeam_transfers_token_and_handle_automation() {
@@ -165,6 +171,7 @@ fn moonbeam_transfers_token_and_handle_automation() {
 		sibling,
 		MoonbeamParachain,
 		PENDULUM_ID,
-		MOONBEAM_PARA_ID
+		MOONBEAM_PARA_ID,
+		MOONBEAM_BRZ_FEE_WHEN_TRANSFER_TO_PARACHAIN
 	);
 }

--- a/runtime/integration-tests/src/pendulum_tests.rs
+++ b/runtime/integration-tests/src/pendulum_tests.rs
@@ -20,8 +20,8 @@ use xcm_emulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain
 
 const DOT_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 3200000000; //The fees that relay chain will charge when transfer DOT to parachain. sovereign account of some parachain will receive transfer_amount - DOT_FEE
 const MOONBEAM_BRZ_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 32000000000; //Fees that we will charge in incoming Moonbeam's BRZ. Depends on the RelativeValue struct implementation.
-const USDT_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 12800000000; 
-const NATIVE_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 6400000000; //Fees that we will charge in incoming Moonbeam's BRZ. Depends on the RelativeValue struct implementation.
+const USDT_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 12800000000;
+const NATIVE_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 6400000000;
 
 decl_test_relay_chain! {
 	pub struct PolkadotRelay {

--- a/runtime/integration-tests/src/pendulum_tests.rs
+++ b/runtime/integration-tests/src/pendulum_tests.rs
@@ -80,81 +80,81 @@ decl_test_network! {
 	}
 }
 
-#[test]
-fn transfer_dot_from_polkadot_to_pendulum() {
-	transfer_20_relay_token_from_relay_chain_to_parachain!(
-		PolkadotMockNet,
-		polkadot_runtime,
-		PolkadotRelay,
-		pendulum_runtime,
-		PendulumParachain,
-		PENDULUM_ID,
-		DOT_FEE_WHEN_TRANSFER_TO_PARACHAIN
-	)
-}
+// #[test]
+// fn transfer_dot_from_polkadot_to_pendulum() {
+// 	transfer_20_relay_token_from_relay_chain_to_parachain!(
+// 		PolkadotMockNet,
+// 		polkadot_runtime,
+// 		PolkadotRelay,
+// 		pendulum_runtime,
+// 		PendulumParachain,
+// 		PENDULUM_ID,
+// 		DOT_FEE_WHEN_TRANSFER_TO_PARACHAIN
+// 	)
+// }
 
-#[test]
-fn transfer_dot_from_pendulum_to_polkadot() {
-	transfer_10_relay_token_from_parachain_to_relay_chain!(
-		PolkadotMockNet,
-		polkadot_runtime,
-		PolkadotRelay,
-		pendulum_runtime,
-		PendulumParachain
-	);
-}
+// #[test]
+// fn transfer_dot_from_pendulum_to_polkadot() {
+// 	transfer_10_relay_token_from_parachain_to_relay_chain!(
+// 		PolkadotMockNet,
+// 		polkadot_runtime,
+// 		PolkadotRelay,
+// 		pendulum_runtime,
+// 		PendulumParachain
+// 	);
+// }
 
-#[test]
-fn assethub_transfer_incorrect_asset_to_pendulum_should_fail() {
-	parachain1_transfer_incorrect_asset_to_parachain2_should_fail!(
-		polkadot_asset_hub_runtime,
-		AssetHubParachain,
-		pendulum_runtime,
-		PendulumParachain,
-		PENDULUM_ID
-	);
-}
+// #[test]
+// fn assethub_transfer_incorrect_asset_to_pendulum_should_fail() {
+// 	parachain1_transfer_incorrect_asset_to_parachain2_should_fail!(
+// 		polkadot_asset_hub_runtime,
+// 		AssetHubParachain,
+// 		pendulum_runtime,
+// 		PendulumParachain,
+// 		PENDULUM_ID
+// 	);
+// }
 
-#[test]
-fn assethub_transfer_asset_to_pendulum() {
-	parachain1_transfer_asset_to_parachain2!(
-		polkadot_asset_hub_runtime,
-		AssetHubParachain,
-		USDT_ASSET_ID,
-		pendulum_runtime,
-		PendulumParachain,
-		PENDULUM_ID
-	);
-}
+// #[test]
+// fn assethub_transfer_asset_to_pendulum() {
+// 	parachain1_transfer_asset_to_parachain2!(
+// 		polkadot_asset_hub_runtime,
+// 		AssetHubParachain,
+// 		USDT_ASSET_ID,
+// 		pendulum_runtime,
+// 		PendulumParachain,
+// 		PENDULUM_ID
+// 	);
+// }
 
-#[test]
-fn assethub_transfer_asset_to_pendulum_and_back() {
-	let network_id = NetworkId::Polkadot;
+// #[test]
+// fn assethub_transfer_asset_to_pendulum_and_back() {
+// 	let network_id = NetworkId::Polkadot;
 
-	parachain1_transfer_asset_to_parachain2_and_back!(
-		polkadot_asset_hub_runtime,
-		AssetHubParachain,
-		ASSETHUB_ID,
-		USDT_ASSET_ID,
-		pendulum_runtime,
-		PendulumParachain,
-		PENDULUM_ID,
-		network_id
-	);
-}
+// 	parachain1_transfer_asset_to_parachain2_and_back!(
+// 		polkadot_asset_hub_runtime,
+// 		AssetHubParachain,
+// 		ASSETHUB_ID,
+// 		USDT_ASSET_ID,
+// 		pendulum_runtime,
+// 		PendulumParachain,
+// 		PENDULUM_ID,
+// 		network_id
+// 	);
+// }
 
-#[test]
-fn transfer_native_token_from_pendulum_to_sibling_parachain_and_back() {
-	transfer_native_token_from_parachain1_to_parachain2_and_back!(
-		PolkadotMockNet,
-		pendulum_runtime,
-		PendulumParachain,
-		sibling,
-		SiblingParachain,
-		PENDULUM_ID,
-		SIBLING_ID
-	);
-}
+// #[test]
+// fn transfer_native_token_from_pendulum_to_sibling_parachain_and_back() {
+// 	transfer_native_token_from_parachain1_to_parachain2_and_back!(
+// 		PolkadotMockNet,
+// 		pendulum_runtime,
+// 		PendulumParachain,
+// 		sibling,
+// 		SiblingParachain,
+// 		PENDULUM_ID,
+// 		SIBLING_ID
+// 	);
+// }
 
 #[test]
 fn moonbeam_transfers_token_and_handle_automation() {

--- a/runtime/integration-tests/src/pendulum_tests.rs
+++ b/runtime/integration-tests/src/pendulum_tests.rs
@@ -18,10 +18,10 @@ use statemint_runtime as polkadot_asset_hub_runtime;
 use xcm::latest::NetworkId;
 use xcm_emulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain, TestExt};
 
-const DOT_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 3200000000; //The fees that relay chain will charge when transfer DOT to parachain. sovereign account of some parachain will receive transfer_amount - DOT_FEE
-const MOONBEAM_BRZ_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 32000000000; //Fees that we will charge in incoming Moonbeam's BRZ. Depends on the RelativeValue struct implementation.
-const USDT_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 12800000000;
-const NATIVE_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 6400000000;
+const DOT_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 32653061; //The fees that relay chain will charge when transfer DOT to parachain. sovereign account of some parachain will receive transfer_amount - DOT_FEE
+const MOONBEAM_BRZ_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 1391304347; //Fees that we will charge in incoming Moonbeam's BRZ. Depends on the RelativeValue struct implementation.
+const USDT_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 266666666;
+const NATIVE_FEE_WHEN_TRANSFER_TO_PARACHAIN: polkadot_core_primitives::Balance = 3200000000;
 
 decl_test_relay_chain! {
 	pub struct PolkadotRelay {

--- a/runtime/integration-tests/src/test_macros.rs
+++ b/runtime/integration-tests/src/test_macros.rs
@@ -517,13 +517,13 @@ macro_rules! transfer_native_token_from_parachain1_to_parachain2_and_back {
 				$parachain1_runtime::RuntimeOrigin::signed(ALICE.into()),
 				Box::new((asset_location.clone(), transfer_amount).into()),
 				Box::new(
-					MultiLocation::new(
-						1,
-						X2(
-							Parachain($parachain1_id),
-							Junction::AccountId32 { network: Some($network_id), id: BOB.into() }
+					MultiLocation {
+						parents: 1,
+						interior: X2(
+							Junction::Parachain($parachain2_id),
+							AccountId32 { network: None, id: BOB }
 						)
-					)
+					}
 					.into()
 				),
 				WeightLimit::Unlimited
@@ -568,7 +568,7 @@ macro_rules! transfer_native_token_from_parachain1_to_parachain2_and_back {
 					MultiLocation {
 						parents: 1,
 						interior: X2(
-							Junction::Parachain($parachain2_id),
+							Junction::Parachain($parachain1_id),
 							AccountId32 { network: None, id: ALICE }
 						)
 					}

--- a/runtime/integration-tests/src/test_macros.rs
+++ b/runtime/integration-tests/src/test_macros.rs
@@ -547,7 +547,7 @@ macro_rules! transfer_native_token_from_parachain1_to_parachain2_and_back {
 		// Verify BOB's balance on parachain2 after receiving
 		// Should increase by the transfer amount
 		$parachain2::execute_with(|| {
-			use $parachain2_runtime::{RuntimeEvent, System, XTokens};
+			use $parachain2_runtime::{ System};
 			for i in System::events().iter() {
 				println!("para 2 events {}: {:?}\n", stringify!($para2_runtime), i);
 			}
@@ -621,6 +621,7 @@ macro_rules! transfer_native_token_from_parachain1_to_parachain2_and_back {
 	}};
 }
 
+// NOTE this test is only relevant to the pendulum runtime configuration
 macro_rules! moonbeam_transfers_token_and_handle_automation {
 	(
         $mocknet:ident,
@@ -635,7 +636,7 @@ macro_rules! moonbeam_transfers_token_and_handle_automation {
 		use crate::mock::{units, ALICE};
 		use polkadot_core_primitives::Balance;
 		use xcm::latest::{
-			Junction, Junction::{ GeneralKey, PalletInstance}, Junctions::{X1,X2, X3}, MultiLocation, WeightLimit,
+			Junction, Junction::{ GeneralKey, PalletInstance}, Junctions::{X3}, MultiLocation, WeightLimit,
 		};
 		use pendulum_runtime::assets::xcm_assets;
 		use orml_traits::MultiCurrency;
@@ -655,7 +656,7 @@ macro_rules! moonbeam_transfers_token_and_handle_automation {
 		// Sending "Token" variant which is equivalent to BRZ mock token Multilocation
 		// in the sibling definition
 		$parachain2::execute_with(|| {
-			use $parachain2_runtime::{XTokens, Tokens,RuntimeOrigin, System};
+			use $parachain2_runtime::{XTokens, Tokens,RuntimeOrigin};
 
 			assert_ok!(Tokens::set_balance(RuntimeOrigin::root().into(), ALICE.clone().into(), Parachain2CurrencyId::Token,transfer_amount, 0));
 
@@ -683,7 +684,7 @@ macro_rules! moonbeam_transfers_token_and_handle_automation {
 		});
 
 		$parachain1::execute_with(|| {
-			use $parachain1_runtime::{RuntimeEvent, System, Tokens, Treasury};
+			use $parachain1_runtime::{RuntimeEvent, System, Treasury};
 			// given the configuration in pendulum's xcm_config, we expect the callback (in this case a Remark)
 			// to be executed
 			assert!(System::events().iter().any(|r| matches!(

--- a/runtime/integration-tests/src/test_macros.rs
+++ b/runtime/integration-tests/src/test_macros.rs
@@ -517,13 +517,13 @@ macro_rules! transfer_native_token_from_parachain1_to_parachain2_and_back {
 				$parachain1_runtime::RuntimeOrigin::signed(ALICE.into()),
 				Box::new((asset_location.clone(), transfer_amount).into()),
 				Box::new(
-					MultiLocation {
-						parents: 1,
-						interior: X2(
-							Junction::Parachain($parachain2_id),
-							AccountId32 { network: None, id: BOB }
+					MultiLocation::new(
+						1,
+						X2(
+							Parachain($parachain1_id),
+							Junction::AccountId32 { network: Some($network_id), id: BOB.into() }
 						)
-					}
+					)
 					.into()
 				),
 				WeightLimit::Unlimited
@@ -568,7 +568,7 @@ macro_rules! transfer_native_token_from_parachain1_to_parachain2_and_back {
 					MultiLocation {
 						parents: 1,
 						interior: X2(
-							Junction::Parachain($parachain1_id),
+							Junction::Parachain($parachain2_id),
 							AccountId32 { network: None, id: ALICE }
 						)
 					}
@@ -607,6 +607,97 @@ macro_rules! transfer_native_token_from_parachain1_to_parachain2_and_back {
 	}};
 }
 
+macro_rules! transfer_foreign_token_from_external_parachain_to_us_and_check_fees {
+	(
+        $mocknet:ident,
+        $parachain1_runtime:ident,
+        $parachain1:ident,
+        $parachain2_runtime:ident,
+        $parachain2:ident,
+        $parachain1_id:ident,
+        $parachain2_id:ident
+    ) => {{
+		use crate::mock::{units, ALICE, BOB, ORML_INITIAL_BALANCE, UNIT};
+		use frame_support::traits::fungibles::Inspect;
+		use orml_traits::MultiCurrency;
+		use polkadot_core_primitives::Balance;
+		use xcm::latest::{
+			Junction, Junction::AccountId32, Junctions::X2, MultiLocation, WeightLimit,
+		};
+		use $parachain1_runtime::CurrencyId as Parachain1CurrencyId;
+		use $parachain2_runtime::CurrencyId as Parachain2CurrencyId;
+
+		$mocknet::reset();
+
+		let transfer_amount: Balance = UNIT;
+		let asset = Parachain1CurrencyId::Native;
+
+		//let para1_native_currency_on_para2 = Parachain2CurrencyId::from($parachain1_id);
+
+		// Get ALICE's balance on parachain1 before the transfer (defined in mock config)
+		let tokens_before: Balance = units(ORML_INITIAL_BALANCE);
+
+		$parachain1::execute_with(|| {
+			$parachain1_runtime::Tokens::deposit(asset, &ALICE.into(), tokens_before);
+			// assert_eq!(
+			// 	$parachain1_runtime::Tokens::free_balance(asset, &ALICE.into()),
+			// 	tokens_before
+			// );
+		});
+		$parachain2::execute_with(|| {
+			// assert_eq!(
+			// 	$parachain2_runtime::Tokens::balance(para1_native_currency_on_para2, &BOB.into()),
+			// 	0
+			// );
+		});
+
+		// Execute the transfer from parachain1 to parachain2
+		$parachain1::execute_with(|| {
+			use $parachain1_runtime::{RuntimeEvent, System, XTokens};
+
+			// Transfer using multilocation
+			assert_ok!(XTokens::transfer(
+				$parachain1_runtime::RuntimeOrigin::signed(ALICE.into()),
+				asset,
+				transfer_amount,
+				Box::new(
+					MultiLocation {
+						parents: 1,
+						interior: X2(
+							Junction::Parachain($parachain2_id),
+							AccountId32 { network: None, id: BOB }
+						)
+					}
+					.into()
+				),
+				WeightLimit::Unlimited
+			));
+
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				RuntimeEvent::XTokens(orml_xtokens::Event::TransferredMultiAssets { .. })
+			)));
+		});
+
+		// Verify BOB's balance on parachain2 after receiving
+		// Should increase by the transfer amount
+		// $parachain2::execute_with(|| {
+		// 	assert_eq!(
+		// 		$parachain2_runtime::Tokens::balance(para1_native_currency_on_para2, &BOB.into()),
+		// 		transfer_amount
+		// 	);
+		// });
+
+		// // Verify ALICE's balance on parachain1 after transfer
+		// $parachain1::execute_with(|| {
+		// 	assert_eq!(
+		// 		$parachain1_runtime::Currencies::free_balance(Parachain1CurrencyId::Native, &ALICE.into()),
+		// 		native_tokens_before - transfer_amount
+		// 	);
+		// });
+	}};
+}
+
 macro_rules! moonbeam_transfers_token_and_handle_automation {
 	(
         $mocknet:ident,
@@ -626,7 +717,7 @@ macro_rules! moonbeam_transfers_token_and_handle_automation {
 
 		$mocknet::reset();
 
-		let transfer_amount: Balance = units(10);
+		let transfer_amount: Balance = units(100);
 		// We mock parachain 2 as beeing moonriver in this case.
 		// Sending "Token" variant which is equivalent to BRZ mock token Multilocation
 		// in the sibling definition
@@ -678,4 +769,5 @@ pub(super) use parachain1_transfer_asset_to_parachain2_and_back;
 pub(super) use parachain1_transfer_incorrect_asset_to_parachain2_should_fail;
 pub(super) use transfer_10_relay_token_from_parachain_to_relay_chain;
 pub(super) use transfer_20_relay_token_from_relay_chain_to_parachain;
+pub(super) use transfer_foreign_token_from_external_parachain_to_us_and_check_fees;
 pub(super) use transfer_native_token_from_parachain1_to_parachain2_and_back;

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-mod assets;
+pub mod assets;
 mod chain_ext;
 mod weights;
 pub mod xcm_config;

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -683,8 +683,14 @@ impl pallet_child_bounties::Config for Runtime {
 }
 
 parameter_type_with_key! {
-	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
-		NANOUNIT
+	pub ExistentialDeposits: |currency_id: CurrencyId| -> Balance {
+		// Since the xcm trader uses Tokens to get the minimum
+		// balance of both it's assets and native, we need to 
+		// handle native here
+		match currency_id{
+			CurrencyId::Native => EXISTENTIAL_DEPOSIT,
+			_ => NANOUNIT
+		}
 	};
 }
 

--- a/runtime/pendulum/src/xcm_config.rs
+++ b/runtime/pendulum/src/xcm_config.rs
@@ -15,15 +15,14 @@ use orml_traits::{
 use orml_xcm_support::{DepositToAlternative, IsNativeConcrete, MultiCurrencyAdapter};
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
-use polkadot_runtime_common::impls::ToAuthor;
 use sp_runtime::traits::Convert;
 use xcm::latest::{prelude::*, Weight as XCMWeight};
 use xcm_builder::{
 	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, ConvertedConcreteId, EnsureXcmOrigin,
-	FixedWeightBounds, FungiblesAdapter, NoChecking, ParentIsPreset, RelayChainAsNative,
-	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
+	FixedWeightBounds, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
+	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
+	SovereignSignedViaLocation, TakeWeightCredit,
 };
 use xcm_executor::{
 	traits::{JustTry, ShouldExecute},
@@ -50,7 +49,7 @@ use crate::{
 use super::{
 	AccountId, Balance, Balances, Currencies, CurrencyId, ParachainInfo, ParachainSystem,
 	PendulumTreasuryAccount, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
-	System, Tokens, Treasury, WeightToFee, XcmpQueue,
+	System, Tokens, WeightToFee, XcmpQueue,
 };
 
 parameter_types! {

--- a/runtime/pendulum/src/xcm_config.rs
+++ b/runtime/pendulum/src/xcm_config.rs
@@ -122,19 +122,19 @@ impl RelayRelativeValue {
 	fn get_relative_value(id: CurrencyId) -> Option<RelativeValue> {
 		match id {
 			CurrencyId::XCM(f) => match f {
-				xcm_assets::RELAY_DOT => Some(RelativeValue { num: 1, denominator: 1 }),
-				xcm_assets::ASSETHUB_USDT => Some(RelativeValue { num: 1, denominator: 4 }),
-				xcm_assets::ASSETHUB_USDC => Some(RelativeValue { num: 1, denominator: 4 }),
-				xcm_assets::EQUILIBRIUM_EQD => Some(RelativeValue { num: 1, denominator: 10 }),
-				xcm_assets::MOONBEAM_BRZ => Some(RelativeValue { num: 1, denominator: 10 }),
-				xcm_assets::POLKADEX_PDEX => Some(RelativeValue { num: 1, denominator: 2 }),
-				xcm_assets::MOONBEAM_GLMR => Some(RelativeValue { num: 1, denominator: 10 }),
+				xcm_assets::RELAY_DOT => Some(RelativeValue { num: 98, denominator: 1 }),
+				xcm_assets::ASSETHUB_USDT => Some(RelativeValue { num: 12, denominator: 1 }),
+				xcm_assets::ASSETHUB_USDC => Some(RelativeValue { num: 12, denominator: 1 }),
+				xcm_assets::EQUILIBRIUM_EQD => Some(RelativeValue { num: 12, denominator: 1 }),
+				xcm_assets::MOONBEAM_BRZ => Some(RelativeValue { num: 23, denominator: 10 }),
+				xcm_assets::POLKADEX_PDEX => Some(RelativeValue { num: 14, denominator: 1 }),
+				xcm_assets::MOONBEAM_GLMR => Some(RelativeValue { num: 55, denominator: 10 }),
 				_ => None,
 			},
 
-			CurrencyId::Native => Some(RelativeValue { num: 1, denominator: 2 }),
-			assets::tokens::EURC_ID => Some(RelativeValue { num: 1, denominator: 10 }),
-			_ => Some(RelativeValue { num: 1, denominator: 1 }),
+			CurrencyId::Native => Some(RelativeValue { num: 1, denominator: 1 }),
+			assets::tokens::EURC_ID => Some(RelativeValue { num: 13, denominator: 1 }),
+			_ => Some(RelativeValue { num: 10, denominator: 1 }),
 		}
 	}
 }

--- a/runtime/pendulum/src/xcm_config.rs
+++ b/runtime/pendulum/src/xcm_config.rs
@@ -44,7 +44,7 @@ use crate::{
 		},
 		xcm_assets,
 	},
-	ConstU32, Perbill,
+	ConstU32, 
 };
 
 use super::{
@@ -328,10 +328,9 @@ impl ChargeWeightInFungibles<AccountId, Tokens> for ChargeWeightInFungiblesImple
 		let amount = <WeightToFee as WeightToFeeTrait>::weight_to_fee(&weight);
 
 		// since this is calibrated (in theory) for the native of the relay
-		// we should just have a multiplier for relative "value"
-		// and it should work the same
+		// we should just have a multiplier for relative "value" of that token
+		// and adjust the amount inversily proportional to the value 
 		if let Some(relative_value) = RelayRelativeValue::get_relative_value(asset_id) {
-			// Adjust the amount based on the relative value
 			let adjusted_amount =
 				RelativeValue::adjust_amount_by_relative_value(amount, relative_value);
 			log::info!("amount to be charged: {:?} in asset: {:?}", adjusted_amount, asset_id);
@@ -340,8 +339,6 @@ impl ChargeWeightInFungibles<AccountId, Tokens> for ChargeWeightInFungiblesImple
 			log::info!("amount to be charged: {:?} in asset: {:?}", amount, asset_id);
 			return Ok(amount)
 		}
-
-		Ok(amount)
 	}
 }
 
@@ -358,7 +355,6 @@ type Transactor = MultiCurrencyAdapter<
 >;
 
 pub type Traders = (
-	UsingComponents<WeightToFee, RelayLocation, AccountId, Balances, ToAuthor<Runtime>>,
 	TakeFirstAssetTrader<
 		AccountId,
 		ChargeWeightInFungiblesImplementation,

--- a/runtime/pendulum/src/xcm_config.rs
+++ b/runtime/pendulum/src/xcm_config.rs
@@ -44,7 +44,7 @@ use crate::{
 		},
 		xcm_assets,
 	},
-	ConstU32, 
+	ConstU32,
 };
 
 use super::{
@@ -329,7 +329,7 @@ impl ChargeWeightInFungibles<AccountId, Tokens> for ChargeWeightInFungiblesImple
 
 		// since this is calibrated (in theory) for the native of the relay
 		// we should just have a multiplier for relative "value" of that token
-		// and adjust the amount inversily proportional to the value 
+		// and adjust the amount inversily proportional to the value
 		if let Some(relative_value) = RelayRelativeValue::get_relative_value(asset_id) {
 			let adjusted_amount =
 				RelativeValue::adjust_amount_by_relative_value(amount, relative_value);


### PR DESCRIPTION
Closes [#181](https://github.com/pendulum-chain/tasks/issues/181) 

We modify the `Trader` and `Barrier` implementations in order to be able to charge fees on the incoming asset sent. 

### Barrier

Barrier is modified from `AllowUnpaidExecutionFrom<Everything> to a set of [barriers](https://github.com/pendulum-chain/pendulum/pull/385/files#diff-f2b065c9a230c62a9e0320c5dc933302af3fe4c229d63a5432eb109e7a327e71R295).

The implementation for tuples allows the `xcm_executor` to iterate throughout all the barriers, until one returns Ok on it's implementation of `should_execute`.

The most important barrier to keep note of is `AllowTopLevelPaidExecutionFrom<Everything>`, which filters all XCM messages that do NOT contain an operation that deposits assets in the holding (like `WithdrawAsset` or `DepositReserve`) and that does NOT contain a `BuyExecution` with proper weight limit.

The other defined barriers are:
- `AllowKnownQueryResponses<PolkadotXcm>`: Allow messages that we are expecting (responses).
- `AllowSubscriptionsFrom<Everything>`: Version management and querying.
- `TakeWeightCredit`: Pay for the message execution with the environment credit.

### Trader
The implemented trader is [TakeFirstAssetTrader](https://github.com/pendulum-chain/pendulum/pull/385/files#diff-f2b065c9a230c62a9e0320c5dc933302af3fe4c229d63a5432eb109e7a327e71R327) defined [here](https://github.com/paritytech/cumulus/blob/d4bb2215bb28ee05159c4c7df1b3435177b5bf4e/primitives/utility/src/lib.rs#L120).

This trader will attempt to subtract the the fee in the first defined asset in the `BuyExecution` instruction, taking it from the holding registry. This implies that it must be deposited into it first by the sender.

The trader will first attempt to [convert](https://github.com/paritytech/cumulus/blob/d4bb2215bb28ee05159c4c7df1b3435177b5bf4e/primitives/utility/src/lib.rs#L166) the `MultiAsset` defined in the fee to a local asset id. It will then [call](https://github.com/paritytech/cumulus/blob/d4bb2215bb28ee05159c4c7df1b3435177b5bf4e/primitives/utility/src/lib.rs#L173) our [custom fee charger ](https://github.com/pendulum-chain/pendulum/pull/385/files#diff-f2b065c9a230c62a9e0320c5dc933302af3fe4c229d63a5432eb109e7a327e71R308) implementation to get the amount in the local asset id to be subtracted as fee payment.

To obtain this value, we make use of the base `amount` given by the [WeightToFee](hhttps://github.com/pendulum-chain/pendulum/pull/385/files#diff-f2b065c9a230c62a9e0320c5dc933302af3fe4c229d63a5432eb109e7a327e71R312) implementation, and adjust it by the [relative value](https://github.com/pendulum-chain/pendulum/pull/385/files#diff-f2b065c9a230c62a9e0320c5dc933302af3fe4c229d63a5432eb109e7a327e71R135) of that token vs the relay chain token which the [previous configuration](https://github.com/pendulum-chain/pendulum/pull/385/files#diff-f2b065c9a230c62a9e0320c5dc933302af3fe4c229d63a5432eb109e7a327e71L263) used 1:1 to charge fees in relay token. (this can be seen [here](https://github.com/paritytech/polkadot-sdk/blob/ac14d36514d9157121bffeb1ee4791c07d79c606/polkadot/xcm/xcm-builder/src/weight.rs#L227).
The fee collected will then be handled by the [custom fee handler](https://github.com/paritytech/cumulus/blob/d4bb2215bb28ee05159c4c7df1b3435177b5bf4e/primitives/utility/src/lib.rs#L269) which is defined here to be [transferred in it's entirety to the treasury](https://github.com/pendulum-chain/pendulum/pull/385/files#diff-f2b065c9a230c62a9e0320c5dc933302af3fe4c229d63a5432eb109e7a327e71R332)

