### PR TITLE
394 bump versions for pendulum runtime upgrade 11

### DIFF
--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -169,7 +169,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("pendulum"),
 	impl_name: create_runtime_str!("pendulum"),
 	authoring_version: 1,
-	spec_version: 10,
+	spec_version: 11,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 10,


### PR DESCRIPTION
Closes #394 . 

### Notes
- We don't require to bump the transaction version ( comparison [here](https://github.com/pendulum-chain/pendulum/compare/pendulum-release-10...394-bump-versions-for-pendulum-runtime-upgrade-11), also spacewalk commits comparison [here](https://github.com/pendulum-chain/spacewalk/compare/20a3dd191dc352f989f90a1a48eacb8ff6d9ac85...22c52abbecda0c1cdaa4187678fe7bcc2d6868c8))
- Tested the upgrade with chopsticks.
