### PR TITLE
bump spec version

### DIFF
--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -249,7 +249,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 12,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 10,
+	transaction_version: 11,
 	state_version: 1,
 };
 

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -246,7 +246,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("pendulum"),
 	impl_name: create_runtime_str!("pendulum"),
 	authoring_version: 1,
-	spec_version: 11,
+	spec_version: 12,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 10,

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -249,7 +249,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 12,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 11,
+	transaction_version: 10,
 	state_version: 1,
 };
 


### PR DESCRIPTION

Closes #404. Required for performing Pendulum's runtime [upgrade](https://github.com/pendulum-chain/tasks/issues/208) 12.

We don't bump transaction version as only pallets were added.