### PR TITLE
Fix `ConvertPrice` implementations

### DIFF
--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -196,7 +196,9 @@ pub struct ConvertPrice;
 
 impl Convert<u128, Option<UnsignedFixedPoint>> for ConvertPrice {
 	fn convert(price: u128) -> Option<UnsignedFixedPoint> {
-		Some(UnsignedFixedPoint::from_inner(price))
+		// The DIA batching server returns the price in 1e12 format, see [here](https://github.com/pendulum-chain/oracle-pallet/blob/716073885de01f923a0fe44a05bd2a0bd45db555/dia-batching-server/src/price_updater.rs#L141)
+		// but our UnsignedFixedPoint implementation expects the price in 1e18 format.
+		Some(UnsignedFixedPoint::from_rational(price, 1_000_000_000_000))
 	}
 }
 

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -229,7 +229,9 @@ cfg_if::cfg_if! {
 pub struct ConvertPrice;
 impl Convert<u128, Option<UnsignedFixedPoint>> for ConvertPrice {
 	fn convert(price: u128) -> Option<UnsignedFixedPoint> {
-		Some(UnsignedFixedPoint::from_inner(price))
+		// The DIA batching server returns the price in 1e12 format, see [here](https://github.com/pendulum-chain/oracle-pallet/blob/716073885de01f923a0fe44a05bd2a0bd45db555/dia-batching-server/src/price_updater.rs#L141)
+		// but our UnsignedFixedPoint implementation expects the price in 1e18 format.
+		Some(UnsignedFixedPoint::from_rational(price, 1_000_000_000_000))
 	}
 }
 

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -196,7 +196,9 @@ pub struct ConvertPrice;
 
 impl Convert<u128, Option<UnsignedFixedPoint>> for ConvertPrice {
 	fn convert(price: u128) -> Option<UnsignedFixedPoint> {
-		Some(UnsignedFixedPoint::from_inner(price))
+		// The DIA batching server returns the price in 1e12 format, see [here](https://github.com/pendulum-chain/oracle-pallet/blob/716073885de01f923a0fe44a05bd2a0bd45db555/dia-batching-server/src/price_updater.rs#L141)
+		// but our UnsignedFixedPoint implementation expects the price in 1e18 format.
+		Some(UnsignedFixedPoint::from_rational(price, 1_000_000_000_000))
 	}
 }
 


### PR DESCRIPTION
<!-- If you added changes to files in the `node` directory or any other changes that would require a re-deployment of the collator nodes, please add the following line to the PR description:
@pendulum-chain/product: This PR adds changes to the node client code that require a **redeployment of the collator nodes** to take effect. 
Please ensure that the collator nodes are redeployed after this PR is merged.  
-->

Instead of using `from_inner()` we create the fixed point number with `from_rational()` and divide it by 10e12 since we know that these are the decimals considered by the batching server. 

<!-- Replace xx with the issue number that is fixed by this pull request. -->
Closes #412. 