### PR TITLE
417 update spacewalk dependencies and bump spec version on pendulum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "staking",
  "stellar-relay",
  "substrate-wasm-builder",
@@ -1194,8 +1194,8 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clients-info"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2065,8 +2065,8 @@ dependencies = [
 
 [[package]]
 name = "currency"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2080,7 +2080,7 @@ dependencies = [
  "serde",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
 ]
 
 [[package]]
@@ -2853,8 +2853,8 @@ dependencies = [
 
 [[package]]
 name = "fee"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -2873,7 +2873,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "staking",
 ]
 
@@ -3100,7 +3100,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "staking",
  "stellar-relay",
  "substrate-wasm-builder",
@@ -4160,8 +4160,8 @@ dependencies = [
 
 [[package]]
 name = "issue"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -4188,7 +4188,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "stellar-relay",
  "vault-registry",
 ]
@@ -5439,8 +5439,8 @@ dependencies = [
 
 [[package]]
 name = "module-issue-rpc"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "jsonrpsee",
  "module-issue-rpc-runtime-api",
@@ -5452,8 +5452,8 @@ dependencies = [
 
 [[package]]
 name = "module-issue-rpc-runtime-api"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5463,8 +5463,8 @@ dependencies = [
 
 [[package]]
 name = "module-oracle-rpc"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5472,20 +5472,20 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
 ]
 
 [[package]]
 name = "module-oracle-rpc-runtime-api"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "serde",
  "sp-api",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
 ]
 
 [[package]]
@@ -5516,8 +5516,8 @@ dependencies = [
 
 [[package]]
 name = "module-redeem-rpc"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "jsonrpsee",
  "module-redeem-rpc-runtime-api",
@@ -5529,8 +5529,8 @@ dependencies = [
 
 [[package]]
 name = "module-redeem-rpc-runtime-api"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5540,8 +5540,8 @@ dependencies = [
 
 [[package]]
 name = "module-replace-rpc"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "jsonrpsee",
  "module-replace-rpc-runtime-api",
@@ -5553,8 +5553,8 @@ dependencies = [
 
 [[package]]
 name = "module-replace-rpc-runtime-api"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5564,8 +5564,8 @@ dependencies = [
 
 [[package]]
 name = "module-vault-registry-rpc"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5578,8 +5578,8 @@ dependencies = [
 
 [[package]]
 name = "module-vault-registry-rpc-runtime-api"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "frame-support",
  "module-oracle-rpc-runtime-api",
@@ -5853,8 +5853,8 @@ dependencies = [
 
 [[package]]
 name = "nomination"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "currency",
  "fee",
@@ -5878,7 +5878,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "staking",
  "vault-registry",
 ]
@@ -6025,8 +6025,8 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "oracle"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "currency",
  "dia-oracle",
@@ -6045,7 +6045,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "spin 0.9.8",
  "staking",
 ]
@@ -6203,7 +6203,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
 ]
 
 [[package]]
@@ -7749,7 +7749,7 @@ dependencies = [
  "sp-session",
  "sp-timestamp",
  "sp-transaction-pool",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
@@ -7855,7 +7855,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "staking",
  "stellar-relay",
  "substrate-wasm-builder",
@@ -9189,8 +9189,8 @@ dependencies = [
 
 [[package]]
 name = "pooled-rewards"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -9205,7 +9205,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
 ]
 
 [[package]]
@@ -9634,8 +9634,8 @@ dependencies = [
 
 [[package]]
 name = "redeem"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "currency",
  "fee",
@@ -9659,7 +9659,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "stellar-relay",
  "vault-registry",
 ]
@@ -9796,8 +9796,8 @@ dependencies = [
 
 [[package]]
 name = "replace"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "currency",
  "fee",
@@ -9823,7 +9823,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "stellar-relay",
  "vault-registry",
 ]
@@ -9840,8 +9840,8 @@ dependencies = [
 
 [[package]]
 name = "reward"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9854,13 +9854,13 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
 ]
 
 [[package]]
 name = "reward-distribution"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -9882,7 +9882,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "staking",
 ]
 
@@ -10101,7 +10101,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "xcm",
  "xcm-executor",
  "zenlink-protocol",
@@ -10146,7 +10146,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-tracing",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "statemine-runtime",
  "statemint-runtime",
  "xcm",
@@ -11629,8 +11629,8 @@ dependencies = [
 
 [[package]]
 name = "security"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12689,8 +12689,8 @@ dependencies = [
 
 [[package]]
 name = "spacewalk-primitives"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "base58",
  "bstringify",
@@ -12753,8 +12753,8 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staking"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12769,7 +12769,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
 ]
 
 [[package]]
@@ -12959,8 +12959,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-relay"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -12973,7 +12973,7 @@ dependencies = [
  "sha2 0.10.7",
  "sp-core",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
 ]
 
 [[package]]
@@ -13963,8 +13963,8 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vault-registry"
-version = "1.0.3"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=22c52abbecda0c1cdaa4187678fe7bcc2d6868c8#22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"
+version = "1.0.4"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=bda384bcc6db3da88198c714851a261dcdea1063#bda384bcc6db3da88198c714851a261dcdea1063"
 dependencies = [
  "currency",
  "fee",
@@ -13991,7 +13991,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.3",
+ "spacewalk-primitives 1.0.4",
  "staking",
 ]
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,37 +15,37 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.145", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 
-module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
+module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
 module-pallet-staking-rpc = { path = "../pallets/parachain-staking/rpc" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
 
 # Local
-amplitude-runtime = {path = "../runtime/amplitude"}
-foucoco-runtime = {path = "../runtime/foucoco"}
-pendulum-runtime = {path = "../runtime/pendulum"}
-development-runtime = {path = "../runtime/development"}
-runtime-common = {path = "../runtime/common"}
+amplitude-runtime = { path = "../runtime/amplitude" }
+foucoco-runtime = { path = "../runtime/foucoco" }
+pendulum-runtime = { path = "../runtime/pendulum" }
+development-runtime = { path = "../runtime/development" }
+runtime-common = { path = "../runtime/common" }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-pallet-multisig = {git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40"}
-pallet-treasury = {git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40"}
+pallet-multisig = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
 pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-executor = { git = "https://github.com/paritytech/substrate",  branch = "polkadot-v0.9.40" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 sc-network-sync = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-service = { git = "https://github.com/paritytech/substrate",  branch = "polkadot-v0.9.40" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 sc-sysinfo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
@@ -87,7 +87,7 @@ cumulus-relay-chain-rpc-interface = { git = "https://github.com/paritytech/cumul
 cumulus-relay-chain-minimal-node = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40" }
 
 #bifrost
-bifrost-farming-rpc-api = { git = "https://github.com/pendulum-chain/bifrost", branch = "polkadot-v0.9.40-farming-add-currencyid-generic"  }
+bifrost-farming-rpc-api = { git = "https://github.com/pendulum-chain/bifrost", branch = "polkadot-v0.9.40-farming-add-currencyid-generic" }
 bifrost-farming-rpc-runtime-api = { git = "https://github.com/pendulum-chain/bifrost", branch = "polkadot-v0.9.40-farming-add-currencyid-generic" }
 
 zenlink-protocol = { git = "https://github.com/pendulum-chain/Zenlink-DEX-Module", branch = "polkadot-v0.9.40-protocol" }
@@ -100,16 +100,16 @@ substrate-build-script-utils = { git = "https://github.com/paritytech/substrate"
 [features]
 default = []
 runtime-benchmarks = [
-	"amplitude-runtime/runtime-benchmarks",
-	"foucoco-runtime/runtime-benchmarks",
-	"pendulum-runtime/runtime-benchmarks",
-	"development-runtime/runtime-benchmarks",
-  	"runtime-common/runtime-benchmarks",
-	"polkadot-cli/runtime-benchmarks",
+    "amplitude-runtime/runtime-benchmarks",
+    "foucoco-runtime/runtime-benchmarks",
+    "pendulum-runtime/runtime-benchmarks",
+    "development-runtime/runtime-benchmarks",
+    "runtime-common/runtime-benchmarks",
+    "polkadot-cli/runtime-benchmarks",
 ]
 try-runtime = [
-	"amplitude-runtime/try-runtime",
-	"foucoco-runtime/try-runtime",
-	"pendulum-runtime/try-runtime",
-	"try-runtime-cli/try-runtime"
+    "amplitude-runtime/try-runtime",
+    "foucoco-runtime/try-runtime",
+    "pendulum-runtime/try-runtime",
+    "try-runtime-cli/try-runtime"
 ]

--- a/pallets/orml-tokens-management-extension/Cargo.toml
+++ b/pallets/orml-tokens-management-extension/Cargo.toml
@@ -5,17 +5,17 @@ name = "orml-tokens-management-extension"
 version = "1.0.0"
 
 [dependencies]
-codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"]}
-scale-info = {version = "2.2.0", default-features = false, features = ["derive"]}
-serde = {version = "1.0.130", default-features = false, features = ["derive"], optional = true}
-sha2 = {version = "0.8.2", default-features = false}
+codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.130", default-features = false, features = ["derive"], optional = true }
+sha2 = { version = "0.8.2", default-features = false }
 
 # Substrate dependencies
-frame-support = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false}
-frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false}
-sp-core = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false}
-sp-runtime = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false}
-sp-std = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false}
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false }
 
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false, optional = true }
 
@@ -28,30 +28,30 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 [dev-dependencies]
 mocktopus = "0.8.0"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-io = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false}
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false }
 
-pallet-balances = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40"}
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 
 # Spacewalk libraries
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
 
 
 [features]
 default = ["std"]
 std = [
-  "serde",
-  "codec/std",
-  "sha2/std",
-  "sp-core/std",
-  "sp-std/std",
-  "sp-runtime/std",
-  "frame-support/std",
-  "frame-system/std",
-  "orml-currencies/std",
-  "orml-tokens/std",
-  "orml-traits/std",
-  "frame-benchmarking/std",
-  "spacewalk-primitives/std"
+    "serde",
+    "codec/std",
+    "sha2/std",
+    "sp-core/std",
+    "sp-std/std",
+    "sp-runtime/std",
+    "frame-support/std",
+    "frame-system/std",
+    "orml-currencies/std",
+    "orml-tokens/std",
+    "orml-traits/std",
+    "frame-benchmarking/std",
+    "spacewalk-primitives/std"
 ]
 
 runtime-benchmarks = [

--- a/pallets/parachain-staking/rpc/Cargo.toml
+++ b/pallets/parachain-staking/rpc/Cargo.toml
@@ -5,10 +5,10 @@ name = "module-pallet-staking-rpc"
 version = "1.0.0"
 
 [dependencies]
-codec = {package = "parity-scale-codec", version = "3.0.0"}
-jsonrpsee = {version = "0.16.0", features = ["server", "macros"]}
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-module-pallet-staking-rpc-runtime-api = {path = "runtime-api"}
-sp-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40"}
-sp-blockchain = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40"}
-sp-runtime = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40"}
+codec = { package = "parity-scale-codec", version = "3.0.0" }
+jsonrpsee = { version = "0.16.0", features = ["server", "macros"] }
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-pallet-staking-rpc-runtime-api = { path = "runtime-api" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }

--- a/pallets/parachain-staking/rpc/runtime-api/Cargo.toml
+++ b/pallets/parachain-staking/rpc/runtime-api/Cargo.toml
@@ -5,22 +5,22 @@ name = "module-pallet-staking-rpc-runtime-api"
 version = "1.0.0"
 
 [dependencies]
-frame-support = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false}
-sp-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false}
-sp-std = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false}
-parity-scale-codec = {version = "3.1.5", default-features = false, features = ["derive"]}
-scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-serde = {version = "1.0.142", default-features = false, optional = true, features = ["derive"]}
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40", default-features = false }
+parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+serde = { version = "1.0.142", default-features = false, optional = true, features = ["derive"] }
 
 [features]
 default = ["std"]
 std = [
-  "serde",
-  "frame-support/std",
-  "scale-info/std",
-  "sp-api/std",
-  "sp-std/std",
-  "parity-scale-codec/std",
-  "module-oracle-rpc-runtime-api/std",
+    "serde",
+    "frame-support/std",
+    "scale-info/std",
+    "sp-api/std",
+    "sp-std/std",
+    "parity-scale-codec/std",
+    "module-oracle-rpc-runtime-api/std",
 ]

--- a/runtime/amplitude/Cargo.toml
+++ b/runtime/amplitude/Cargo.toml
@@ -27,27 +27,27 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 
 # Custom libraries for Spacewalk
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
 module-pallet-staking-rpc-runtime-api = { path = "../../pallets/parachain-staking/rpc/runtime-api", default-features = false }
-pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
+pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
 
 
 # Substrate
@@ -104,11 +104,11 @@ orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-modu
 # KILT
 parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
 
-orml-currencies-allowance-extension = {path = "../../pallets/orml-currencies-allowance-extension", default-features = false}
+orml-currencies-allowance-extension = { path = "../../pallets/orml-currencies-allowance-extension", default-features = false }
 
 
 # Pendulum Pallets
-vesting-manager = {path = "../../pallets/vesting-manager", default-features = false}
+vesting-manager = { path = "../../pallets/vesting-manager", default-features = false }
 
 # DIA
 dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.40" }
@@ -181,9 +181,9 @@ std = [
     "pallet-contracts-primitives/std",
     "pallet-democracy/std",
     "pallet-identity/std",
-	"pallet-multisig/std",
+    "pallet-multisig/std",
     "pallet-preimage/std",
-	"pallet-proxy/std",
+    "pallet-proxy/std",
     "pallet-insecure-randomness-collective-flip/std",
     "pallet-scheduler/std",
     "pallet-session/std",
@@ -218,7 +218,6 @@ std = [
     "zenlink-protocol-runtime-api/std",
     "bifrost-farming/std",
     "bifrost-farming-rpc-runtime-api/std",
-    
     #custom libraries from spacewalk
     "security/std",
     "staking/std",
@@ -238,11 +237,10 @@ std = [
     "module-pallet-staking-rpc-runtime-api/std",
     "module-vault-registry-rpc-runtime-api/std",
     "spacewalk-primitives/std",
-	# custom libraries from pendulum
-	"orml-currencies-allowance-extension/std",
-	"parachain-staking/std",
-	"vesting-manager/std",
-
+    # custom libraries from pendulum
+    "orml-currencies-allowance-extension/std",
+    "parachain-staking/std",
+    "vesting-manager/std",
 ]
 
 runtime-benchmarks = [
@@ -253,25 +251,22 @@ runtime-benchmarks = [
     "frame-system/runtime-benchmarks",
     "pallet-balances/runtime-benchmarks",
     "pallet-timestamp/runtime-benchmarks",
-
-	"fee/runtime-benchmarks",
-	"issue/runtime-benchmarks",
-	"nomination/runtime-benchmarks",
-	"oracle/runtime-benchmarks",
-	"redeem/runtime-benchmarks",
-	"replace/runtime-benchmarks",
-	"stellar-relay/runtime-benchmarks",
-	"vault-registry/runtime-benchmarks",
-
+    "fee/runtime-benchmarks",
+    "issue/runtime-benchmarks",
+    "nomination/runtime-benchmarks",
+    "oracle/runtime-benchmarks",
+    "redeem/runtime-benchmarks",
+    "replace/runtime-benchmarks",
+    "stellar-relay/runtime-benchmarks",
+    "vault-registry/runtime-benchmarks",
     "pallet-xcm/runtime-benchmarks",
     "sp-runtime/runtime-benchmarks",
     "xcm-builder/runtime-benchmarks",
     "cumulus-pallet-session-benchmarking/runtime-benchmarks",
     "cumulus-pallet-xcmp-queue/runtime-benchmarks",
-	"pallet-collective/runtime-benchmarks",
-
+    "pallet-collective/runtime-benchmarks",
     "runtime-common/runtime-benchmarks",
-	"orml-currencies-allowance-extension/runtime-benchmarks"
+    "orml-currencies-allowance-extension/runtime-benchmarks"
 ]
 
 try-runtime = [
@@ -289,9 +284,9 @@ try-runtime = [
     "pallet-contracts/try-runtime",
     "pallet-democracy/try-runtime",
     "pallet-identity/try-runtime",
-	"pallet-multisig/try-runtime",
+    "pallet-multisig/try-runtime",
     "pallet-preimage/try-runtime",
-	"pallet-proxy/try-runtime",
+    "pallet-proxy/try-runtime",
     "pallet-insecure-randomness-collective-flip/try-runtime",
     "pallet-scheduler/try-runtime",
     "pallet-session/try-runtime",
@@ -300,20 +295,16 @@ try-runtime = [
     "pallet-utility/try-runtime",
     "pallet-vesting/try-runtime",
     "pallet-xcm/try-runtime",
-    
     "parachain-staking/try-runtime",
-
     "cumulus-pallet-aura-ext/try-runtime",
     "cumulus-pallet-dmp-queue/try-runtime",
     "cumulus-pallet-parachain-system/try-runtime",
     "cumulus-pallet-xcm/try-runtime",
     "cumulus-pallet-xcmp-queue/try-runtime",
-
     "orml-asset-registry/try-runtime",
     "orml-currencies/try-runtime",
     "orml-tokens/try-runtime",
     "orml-xtokens/try-runtime",
-
     "stellar-relay/try-runtime",
     "issue/try-runtime",
     "currency/try-runtime",
@@ -328,12 +319,9 @@ try-runtime = [
     "pooled-rewards/try-runtime",
     "clients-info/try-runtime",
     "reward-distribution/try-runtime",
-
     "dia-oracle/try-runtime",
     "orml-currencies-allowance-extension/try-runtime",
     "vesting-manager/try-runtime",
-    
     "bifrost-farming/try-runtime",
-
     "zenlink-protocol/try-runtime",
 ]

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1129,6 +1129,7 @@ impl<K, V, A> orml_traits::DataProvider<K, V> for DataFeederBenchmark<K, V, A> {
 impl oracle::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = oracle::SubstrateWeight<Runtime>;
+	type DecimalsLookup = spacewalk_primitives::AmplitudeDecimalsLookup;
 	type DataProvider = DataProviderImpl;
 	#[cfg(feature = "runtime-benchmarks")]
 	type DataFeeder = MockDataFeeder<Self::AccountId, Moment>;

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -579,8 +579,8 @@ impl pallet_democracy::Config for Runtime {
 	type EnactmentPeriod = EnactmentPeriod;
 	type LaunchPeriod = LaunchPeriod;
 	type VotingPeriod = VotingPeriod;
-	type VoteLockingPeriod = EnactmentPeriod;
 	// Same as EnactmentPeriod
+	type VoteLockingPeriod = EnactmentPeriod;
 	type MinimumDeposit = MinimumDeposit;
 	/// A straight majority of the council can decide what their next motion is.
 	type ExternalOrigin =

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -33,7 +33,7 @@ orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-modu
 dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.40" }
 zenlink-protocol = { git = "https://github.com/pendulum-chain/Zenlink-DEX-Module", default-features = false, branch = "polkadot-v0.9.40-protocol" }
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
 
 [features]
 default = [
@@ -56,7 +56,7 @@ std = [
     "dia-oracle/std",
     "orml-asset-registry/std",
     "orml-xcm-support/std",
-	"zenlink-protocol/std",
+    "zenlink-protocol/std",
     "spacewalk-primitives/std",
 ]
 

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -28,27 +28,27 @@ cfg-if = "1.0.0"
 runtime-common = { path = "../common", default-features = false }
 
 # custom libraries from spacewalk
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
 
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
 module-pallet-staking-rpc-runtime-api = { path = "../../pallets/parachain-staking/rpc/runtime-api", default-features = false }
 
 # Substrate
@@ -105,9 +105,9 @@ orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-modu
 # KILT
 parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
 
-orml-currencies-allowance-extension = {path = "../../pallets/orml-currencies-allowance-extension", default-features = false}
-orml-tokens-management-extension = {path = "../../pallets/orml-tokens-management-extension", default-features = false}
-treasury-buyout-extension = {path = "../../pallets/treasury-buyout-extension", default-features = false}
+orml-currencies-allowance-extension = { path = "../../pallets/orml-currencies-allowance-extension", default-features = false }
+orml-tokens-management-extension = { path = "../../pallets/orml-tokens-management-extension", default-features = false }
+treasury-buyout-extension = { path = "../../pallets/treasury-buyout-extension", default-features = false }
 
 # DIA
 dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.40" }
@@ -182,9 +182,9 @@ std = [
     "pallet-contracts-primitives/std",
     "pallet-democracy/std",
     "pallet-identity/std",
-	"pallet-multisig/std",
+    "pallet-multisig/std",
     "pallet-preimage/std",
-	"pallet-proxy/std",
+    "pallet-proxy/std",
     "pallet-insecure-randomness-collective-flip/std",
     "pallet-scheduler/std",
     "pallet-session/std",
@@ -221,7 +221,6 @@ std = [
     "xcm/std",
     "zenlink-protocol/std",
     "zenlink-protocol-runtime-api/std",
-    
     #custom libraries from spacewalk
     "currency/std",
     "security/std",
@@ -260,16 +259,15 @@ runtime-benchmarks = [
     "xcm-builder/runtime-benchmarks",
     "cumulus-pallet-session-benchmarking/runtime-benchmarks",
     "cumulus-pallet-xcmp-queue/runtime-benchmarks",
-	"pallet-collective/runtime-benchmarks",
-
-	"fee/runtime-benchmarks",
-	"issue/runtime-benchmarks",
-	"nomination/runtime-benchmarks",
-	"oracle/runtime-benchmarks",
-	"redeem/runtime-benchmarks",
-	"replace/runtime-benchmarks",
-	"stellar-relay/runtime-benchmarks",
-	"vault-registry/runtime-benchmarks",
+    "pallet-collective/runtime-benchmarks",
+    "fee/runtime-benchmarks",
+    "issue/runtime-benchmarks",
+    "nomination/runtime-benchmarks",
+    "oracle/runtime-benchmarks",
+    "redeem/runtime-benchmarks",
+    "replace/runtime-benchmarks",
+    "stellar-relay/runtime-benchmarks",
+    "vault-registry/runtime-benchmarks",
     "oracle/testing-utils",
     "runtime-common/runtime-benchmarks",
     "orml-currencies-allowance-extension/runtime-benchmarks",
@@ -304,20 +302,16 @@ try-runtime = [
     "pallet-utility/try-runtime",
     "pallet-vesting/try-runtime",
     "pallet-xcm/try-runtime",
-    
     "parachain-staking/try-runtime",
-
     "cumulus-pallet-aura-ext/try-runtime",
     "cumulus-pallet-dmp-queue/try-runtime",
     "cumulus-pallet-parachain-system/try-runtime",
     "cumulus-pallet-xcm/try-runtime",
     "cumulus-pallet-xcmp-queue/try-runtime",
-
     "orml-asset-registry/try-runtime",
     "orml-currencies/try-runtime",
     "orml-tokens/try-runtime",
     "orml-xtokens/try-runtime",
-
     "stellar-relay/try-runtime",
     "issue/try-runtime",
     "currency/try-runtime",
@@ -332,14 +326,10 @@ try-runtime = [
     "pooled-rewards/try-runtime",
     "clients-info/try-runtime",
     "reward-distribution/try-runtime",
-
     "dia-oracle/try-runtime",
     "orml-currencies-allowance-extension/try-runtime",
     "orml-tokens-management-extension/try-runtime",
-
     "treasury-buyout-extension/try-runtime",
-    
     "bifrost-farming/try-runtime",
-
     "zenlink-protocol/try-runtime",
 ]

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -10,6 +10,7 @@ mod assets;
 mod weights;
 pub mod xcm_config;
 pub mod zenlink;
+
 use crate::zenlink::*;
 use xcm::v3::MultiLocation;
 use zenlink_protocol::{AssetBalance, MultiAssetsHandler, PairInfo};
@@ -175,6 +176,7 @@ pub type Executive = frame_executive::Executive<
 >;
 
 pub struct SpacewalkNativeCurrency;
+
 impl oracle::dia::NativeCurrencyKey for SpacewalkNativeCurrency {
 	fn native_symbol() -> Vec<u8> {
 		"AMPE".as_bytes().to_vec()
@@ -227,6 +229,7 @@ cfg_if::cfg_if! {
 }
 
 pub struct ConvertPrice;
+
 impl Convert<u128, Option<UnsignedFixedPoint>> for ConvertPrice {
 	fn convert(price: u128) -> Option<UnsignedFixedPoint> {
 		// The DIA batching server returns the price in 1e12 format, see [here](https://github.com/pendulum-chain/oracle-pallet/blob/716073885de01f923a0fe44a05bd2a0bd45db555/dia-batching-server/src/price_updater.rs#L141)
@@ -236,6 +239,7 @@ impl Convert<u128, Option<UnsignedFixedPoint>> for ConvertPrice {
 }
 
 pub struct ConvertMoment;
+
 impl Convert<u64, Option<Moment>> for ConvertMoment {
 	fn convert(moment: u64) -> Option<Moment> {
 		// The provided moment is in seconds, but we need milliseconds
@@ -254,6 +258,7 @@ impl Convert<u64, Option<Moment>> for ConvertMoment {
 ///   - Setting it to `0` will essentially disable the weight fee.
 ///   - Setting it to `1` will cause the literal `#[weight = x]` values to be charged.
 pub struct WeightToFee;
+
 impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
@@ -354,6 +359,7 @@ parameter_types! {
 }
 
 pub struct BaseFilter;
+
 impl Contains<RuntimeCall> for BaseFilter {
 	fn contains(call: &RuntimeCall) -> bool {
 		match call {
@@ -510,6 +516,7 @@ parameter_types! {
 type NegativeImbalance = <Balances as FrameCurrency<AccountId>>::NegativeImbalance;
 
 pub struct DealWithFees;
+
 impl OnUnbalanced<NegativeImbalance> for DealWithFees {
 	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
 		if let Some(mut fees) = fees_then_tips.next() {
@@ -609,7 +616,8 @@ impl pallet_democracy::Config for Runtime {
 	type EnactmentPeriod = EnactmentPeriod;
 	type LaunchPeriod = LaunchPeriod;
 	type VotingPeriod = VotingPeriod;
-	type VoteLockingPeriod = EnactmentPeriod; // Same as EnactmentPeriod
+	type VoteLockingPeriod = EnactmentPeriod;
+	// Same as EnactmentPeriod
 	type MinimumDeposit = MinimumDeposit;
 	/// A straight majority of the council can decide what their next motion is.
 	type ExternalOrigin =
@@ -662,6 +670,7 @@ parameter_types! {
 }
 
 type CouncilCollective = pallet_collective::Instance1;
+
 impl pallet_collective::Config<CouncilCollective> for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 	type Proposal = RuntimeCall;
@@ -681,6 +690,7 @@ parameter_types! {
 }
 
 type TechnicalCollective = pallet_collective::Instance2;
+
 impl pallet_collective::Config<TechnicalCollective> for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 	type Proposal = RuntimeCall;
@@ -821,6 +831,7 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
 }
 
 pub struct DustRemovalWhitelist;
+
 impl Contains<AccountId> for DustRemovalWhitelist {
 	fn contains(a: &AccountId) -> bool {
 		get_all_module_accounts().contains(a)
@@ -828,6 +839,7 @@ impl Contains<AccountId> for DustRemovalWhitelist {
 }
 
 pub struct CurrencyHooks<T>(PhantomData<T>);
+
 impl<T: orml_tokens::Config> MutationHooks<T::AccountId, T::CurrencyId, T::Balance>
 	for CurrencyHooks<T>
 {
@@ -965,7 +977,9 @@ impl pallet_vesting::Config for Runtime {
 	type WeightInfo = pallet_vesting::weights::SubstrateWeight<Runtime>;
 	const MAX_VESTING_SCHEDULES: u32 = 10;
 }
+
 pub struct CurrencyIdCheckerImpl;
+
 impl orml_tokens_management_extension::CurrencyIdCheck for CurrencyIdCheckerImpl {
 	type CurrencyId = CurrencyId;
 
@@ -994,7 +1008,9 @@ impl orml_tokens_management_extension::Config for Runtime {
 	type DepositCurrency = DepositCurrency;
 	type AssetDeposit = AssetDeposit;
 }
+
 pub struct OraclePriceGetter(Oracle);
+
 impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	fn get_price<FixedNumber>(currency_id: CurrencyId) -> Result<FixedNumber, DispatchError>
@@ -1599,6 +1615,7 @@ where
 }
 
 pub struct CurrencyConvert;
+
 impl currency::CurrencyConversion<currency::Amount<Runtime>, CurrencyId> for CurrencyConvert {
 	fn convert(
 		amount: &currency::Amount<Runtime>,
@@ -1661,6 +1678,7 @@ impl staking::Config for Runtime {
 impl oracle::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = oracle::SubstrateWeight<Runtime>;
+	type DecimalsLookup = spacewalk_primitives::AmplitudeDecimalsLookup;
 	type DataProvider = DataProviderImpl;
 	#[cfg(feature = "runtime-benchmarks")]
 	type DataFeeder = MockDataFeeder<Self::AccountId, Moment>;

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -284,7 +284,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("foucoco"),
 	impl_name: create_runtime_str!("foucoco"),
 	authoring_version: 1,
-	spec_version: 9,
+	spec_version: 10,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 8,

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -616,8 +616,8 @@ impl pallet_democracy::Config for Runtime {
 	type EnactmentPeriod = EnactmentPeriod;
 	type LaunchPeriod = LaunchPeriod;
 	type VotingPeriod = VotingPeriod;
-	type VoteLockingPeriod = EnactmentPeriod;
 	// Same as EnactmentPeriod
+	type VoteLockingPeriod = EnactmentPeriod;
 	type MinimumDeposit = MinimumDeposit;
 	/// A straight majority of the council can decide what their next motion is.
 	type ExternalOrigin =

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -11,7 +11,7 @@ scale-info = { version = "2.1.2", features = ["derive"] }
 serde = { version = "1.0.144", features = ["derive"] }
 
 # Spacewalk libraries
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
 
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
@@ -38,27 +38,27 @@ polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", bran
 
 xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", rev = "bea35c799d725a4233db6b9108ee2ed5bbfc1aed" }
 
-cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.40"}
-cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.40"}
-cumulus-pallet-xcm = {git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.40"}
-cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.40"}
-cumulus-primitives-utility = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40"}
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.40" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.40" }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.40" }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.40" }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40" }
 parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.40" }
 
 statemint-runtime = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.40" }
 statemine-runtime = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.40" }
 
-orml-xcm = {git = "https://github.com/open-web3-stack/open-runtime-module-library.git",  branch = "polkadot-v0.9.40" }
-orml-xcm-support = {git = "https://github.com/open-web3-stack/open-runtime-module-library.git",  branch = "polkadot-v0.9.40" }
-orml-traits = {git = "https://github.com/open-web3-stack/open-runtime-module-library.git",  branch = "polkadot-v0.9.40" }
-orml-tokens = {git = "https://github.com/open-web3-stack/open-runtime-module-library.git",  branch = "polkadot-v0.9.40" }
-orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library",  branch = "polkadot-v0.9.40" }
+orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v0.9.40" }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v0.9.40" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v0.9.40" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v0.9.40" }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.40" }
 
 # Local
-runtime-common = {path = "../common", default-features = false}
+runtime-common = { path = "../common", default-features = false }
 
 pendulum-runtime = { path = "../pendulum" }
-amplitude-runtime = {path = "../amplitude" }
+amplitude-runtime = { path = "../amplitude" }
 
 [features]
 default = ["std"]

--- a/runtime/pendulum/Cargo.toml
+++ b/runtime/pendulum/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.1.0"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40"}
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
@@ -24,113 +24,113 @@ serde = { version = "1.0.144", optional = true, features = ["derive"] }
 smallvec = "1.9.0"
 
 # Local
-runtime-common = {path = "../common", default-features = false}
+runtime-common = { path = "../common", default-features = false }
 
 # Custom libraries for Spacewalk
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8" }
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
 module-pallet-staking-rpc-runtime-api = { path = "../../pallets/parachain-staking/rpc/runtime-api", default-features = false }
-pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
-reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "22c52abbecda0c1cdaa4187678fe7bcc2d6868c8"}
+pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
+reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "bda384bcc6db3da88198c714851a261dcdea1063" }
 
 # Substrate
-frame-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40"}
-frame-executive = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-frame-support = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-frame-system = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40"}
-frame-system-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-frame-try-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40"}
-pallet-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-authorship = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-balances = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-bounties = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-child-bounties = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-collective = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-contracts = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-contracts-primitives = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-democracy = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-identity = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-multisig = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-preimage = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-proxy = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-insecure-randomness-collective-flip = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-scheduler = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-timestamp = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-transaction-payment = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-transaction-payment-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-treasury = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-utility = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-pallet-vesting = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-sp-block-builder = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-sp-consensus-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-sp-inherents = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-sp-io = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-sp-offchain = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-sp-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-sp-transaction-pool = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
-sp-version = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40"}
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
+frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
+pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-bounties = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-child-bounties = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-contracts = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-identity = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-preimage = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 # Open Runtime Module Library
-orml-asset-registry = {git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.40" }
-orml-currencies = {git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.40" }
-orml-traits = {git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.40" }
-orml-tokens = {git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.40" }
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.40" }
+orml-currencies = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.40" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.40" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.40" }
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.40" }
 orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.40" }
 
 # KILT
-parachain-staking = {path = "../../pallets/parachain-staking", default-features = false}
+parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
 
-orml-currencies-allowance-extension = {path = "../../pallets/orml-currencies-allowance-extension", default-features = false}
+orml-currencies-allowance-extension = { path = "../../pallets/orml-currencies-allowance-extension", default-features = false }
 
 # DIA
-dia-oracle = {git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.40"}
-dia-oracle-runtime-api = {git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.40"}
+dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.40" }
+dia-oracle-runtime-api = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.40" }
 
 # Pendulum Pallets
-vesting-manager = {path = "../../pallets/vesting-manager", default-features = false}
+vesting-manager = { path = "../../pallets/vesting-manager", default-features = false }
 
 # Polkadot
-pallet-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40"}
-polkadot-parachain = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40"}
-polkadot-runtime-common = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40"}
-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40"}
-xcm-builder = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40"}
-xcm-executor = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40"}
+pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
+xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
+xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
 
 # Cumulus
-cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40"}
-cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40"}
-cumulus-pallet-parachain-system = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40"}
-cumulus-pallet-session-benchmarking = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40"}
-cumulus-pallet-xcm = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40"}
-cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40"}
-cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40"}
-cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40"}
-cumulus-primitives-utility = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40"}
-parachain-info = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40"}
+cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40" }
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40" }
+cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40" }
+cumulus-pallet-session-benchmarking = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40" }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40" }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40" }
+cumulus-primitives-timestamp = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40" }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40" }
+parachain-info = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.40" }
 
 # Zenlink
 zenlink-protocol = { git = "https://github.com/pendulum-chain/Zenlink-DEX-Module", default-features = false, branch = "polkadot-v0.9.40-protocol" }
@@ -142,198 +142,186 @@ bifrost-farming-rpc-runtime-api = { git = "https://github.com/pendulum-chain/bif
 
 [features]
 default = [
-  "std",
+    "std",
 ]
 std = [
-  "codec/std",
-  "log/std",
-  "scale-info/std",
-  "serde",
-  "cumulus-pallet-aura-ext/std",
-  "cumulus-pallet-dmp-queue/std",
-  "cumulus-pallet-parachain-system/std",
-  "cumulus-pallet-xcm/std",
-  "cumulus-pallet-xcmp-queue/std",
-  "cumulus-primitives-core/std",
-  "cumulus-primitives-timestamp/std",
-  "cumulus-primitives-utility/std",
-  "dia-oracle/std",
-  "dia-oracle-runtime-api/std",
-  "frame-executive/std",
-  "frame-support/std",
-  "frame-system-rpc-runtime-api/std",
-  "frame-system/std",
-  "frame-try-runtime/std",
-  "module-pallet-staking-rpc-runtime-api/std",
-  "module-oracle-rpc-runtime-api/std",
-  "orml-asset-registry/std",
-  "orml-currencies/std",
-  "orml-traits/std",
-  "orml-tokens/std",
-  "orml-xtokens/std",
-  "orml-xcm-support/std",
-  "pallet-aura/std",
-  "pallet-authorship/std",
-  "pallet-balances/std",
-  "pallet-bounties/std",
-  "pallet-child-bounties/std",
-  "pallet-collective/std",
-  "pallet-contracts/std",
-  "pallet-contracts-primitives/std",
-  "pallet-democracy/std",
-  "pallet-identity/std",
-  "pallet-multisig/std",
-  "pallet-preimage/std",
-  "pallet-proxy/std",
-  "pallet-insecure-randomness-collective-flip/std",
-  "pallet-scheduler/std",
-  "pallet-session/std",
-  "pallet-timestamp/std",
-  "pallet-transaction-payment-rpc-runtime-api/std",
-  "pallet-transaction-payment/std",
-  "pallet-treasury/std",
-  "pallet-utility/std",
-  "pallet-vesting/std",
-  "pallet-xcm/std",
-  "parachain-info/std",
-  "polkadot-parachain/std",
-  "polkadot-runtime-common/std",
-  "runtime-common/std",
-  "sp-api/std",
-  "sp-block-builder/std",
-  "sp-consensus-aura/std",
-  "sp-core/std",
-  "sp-inherents/std",
-  "sp-io/std",
-  "sp-offchain/std",
-  "sp-runtime/std",
-  "sp-session/std",
-  "sp-std/std",
-  "sp-transaction-pool/std",
-  "sp-version/std",
-  "xcm-builder/std",
-  "xcm-executor/std",
-  "xcm/std",
-  "zenlink-protocol/std",
-  "zenlink-protocol-runtime-api/std",
-  "bifrost-farming/std",
-  "bifrost-farming-rpc-runtime-api/std",
-
-  #custom libraries from spacewalk
-  "security/std",
-  "staking/std",
-  "oracle/std",
-  "stellar-relay/std",
-  "fee/std",
-  "vault-registry/std",
-  "redeem/std",
-  "issue/std",
-  "currency/std",
-  "nomination/std",
-  "replace/std",
-  "module-issue-rpc-runtime-api/std",
-  "module-oracle-rpc-runtime-api/std",
-  "module-redeem-rpc-runtime-api/std",
-  "module-replace-rpc-runtime-api/std",
-  "module-pallet-staking-rpc-runtime-api/std",
-  "module-vault-registry-rpc-runtime-api/std",
-  "spacewalk-primitives/std",
-
-  # custom libraries from pendulum
-  "orml-currencies-allowance-extension/std",
-  "parachain-staking/std",
-  "vesting-manager/std",
+    "codec/std",
+    "log/std",
+    "scale-info/std",
+    "serde",
+    "cumulus-pallet-aura-ext/std",
+    "cumulus-pallet-dmp-queue/std",
+    "cumulus-pallet-parachain-system/std",
+    "cumulus-pallet-xcm/std",
+    "cumulus-pallet-xcmp-queue/std",
+    "cumulus-primitives-core/std",
+    "cumulus-primitives-timestamp/std",
+    "cumulus-primitives-utility/std",
+    "dia-oracle/std",
+    "dia-oracle-runtime-api/std",
+    "frame-executive/std",
+    "frame-support/std",
+    "frame-system-rpc-runtime-api/std",
+    "frame-system/std",
+    "frame-try-runtime/std",
+    "module-pallet-staking-rpc-runtime-api/std",
+    "module-oracle-rpc-runtime-api/std",
+    "orml-asset-registry/std",
+    "orml-currencies/std",
+    "orml-traits/std",
+    "orml-tokens/std",
+    "orml-xtokens/std",
+    "orml-xcm-support/std",
+    "pallet-aura/std",
+    "pallet-authorship/std",
+    "pallet-balances/std",
+    "pallet-bounties/std",
+    "pallet-child-bounties/std",
+    "pallet-collective/std",
+    "pallet-contracts/std",
+    "pallet-contracts-primitives/std",
+    "pallet-democracy/std",
+    "pallet-identity/std",
+    "pallet-multisig/std",
+    "pallet-preimage/std",
+    "pallet-proxy/std",
+    "pallet-insecure-randomness-collective-flip/std",
+    "pallet-scheduler/std",
+    "pallet-session/std",
+    "pallet-timestamp/std",
+    "pallet-transaction-payment-rpc-runtime-api/std",
+    "pallet-transaction-payment/std",
+    "pallet-treasury/std",
+    "pallet-utility/std",
+    "pallet-vesting/std",
+    "pallet-xcm/std",
+    "parachain-info/std",
+    "polkadot-parachain/std",
+    "polkadot-runtime-common/std",
+    "runtime-common/std",
+    "sp-api/std",
+    "sp-block-builder/std",
+    "sp-consensus-aura/std",
+    "sp-core/std",
+    "sp-inherents/std",
+    "sp-io/std",
+    "sp-offchain/std",
+    "sp-runtime/std",
+    "sp-session/std",
+    "sp-std/std",
+    "sp-transaction-pool/std",
+    "sp-version/std",
+    "xcm-builder/std",
+    "xcm-executor/std",
+    "xcm/std",
+    "zenlink-protocol/std",
+    "zenlink-protocol-runtime-api/std",
+    "bifrost-farming/std",
+    "bifrost-farming-rpc-runtime-api/std",
+    #custom libraries from spacewalk
+    "security/std",
+    "staking/std",
+    "oracle/std",
+    "stellar-relay/std",
+    "fee/std",
+    "vault-registry/std",
+    "redeem/std",
+    "issue/std",
+    "currency/std",
+    "nomination/std",
+    "replace/std",
+    "module-issue-rpc-runtime-api/std",
+    "module-oracle-rpc-runtime-api/std",
+    "module-redeem-rpc-runtime-api/std",
+    "module-replace-rpc-runtime-api/std",
+    "module-pallet-staking-rpc-runtime-api/std",
+    "module-vault-registry-rpc-runtime-api/std",
+    "spacewalk-primitives/std",
+    # custom libraries from pendulum
+    "orml-currencies-allowance-extension/std",
+    "parachain-staking/std",
+    "vesting-manager/std",
 ]
 
 runtime-benchmarks = [
-  "hex-literal",
-  "frame-benchmarking/runtime-benchmarks",
-  "frame-support/runtime-benchmarks",
-  "frame-system-benchmarking/runtime-benchmarks",
-  "frame-system/runtime-benchmarks",
-  "pallet-balances/runtime-benchmarks",
-  "pallet-timestamp/runtime-benchmarks",
-
-  "fee/runtime-benchmarks",
-  "issue/runtime-benchmarks",
-  "nomination/runtime-benchmarks",
-  "oracle/runtime-benchmarks",
-  "redeem/runtime-benchmarks",
-  "replace/runtime-benchmarks",
-  "stellar-relay/runtime-benchmarks",
-  "vault-registry/runtime-benchmarks",
-
-  "pallet-xcm/runtime-benchmarks",
-  "sp-runtime/runtime-benchmarks",
-  "xcm-builder/runtime-benchmarks",
-  "cumulus-pallet-session-benchmarking/runtime-benchmarks",
-  "cumulus-pallet-xcmp-queue/runtime-benchmarks",
-  "pallet-collective/runtime-benchmarks",
-
-  "runtime-common/runtime-benchmarks",
-  "orml-currencies-allowance-extension/runtime-benchmarks"
+    "hex-literal",
+    "frame-benchmarking/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system-benchmarking/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "pallet-balances/runtime-benchmarks",
+    "pallet-timestamp/runtime-benchmarks",
+    "fee/runtime-benchmarks",
+    "issue/runtime-benchmarks",
+    "nomination/runtime-benchmarks",
+    "oracle/runtime-benchmarks",
+    "redeem/runtime-benchmarks",
+    "replace/runtime-benchmarks",
+    "stellar-relay/runtime-benchmarks",
+    "vault-registry/runtime-benchmarks",
+    "pallet-xcm/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
+    "xcm-builder/runtime-benchmarks",
+    "cumulus-pallet-session-benchmarking/runtime-benchmarks",
+    "cumulus-pallet-xcmp-queue/runtime-benchmarks",
+    "pallet-collective/runtime-benchmarks",
+    "runtime-common/runtime-benchmarks",
+    "orml-currencies-allowance-extension/runtime-benchmarks"
 ]
 
 try-runtime = [
-  "frame-executive/try-runtime",
-  "frame-try-runtime",
-  "frame-system/try-runtime",
-  "parachain-info/try-runtime",
-  "pallet-timestamp/try-runtime",
-  "pallet-aura/try-runtime",  
-  "pallet-authorship/try-runtime",
-  "pallet-balances/try-runtime",
-  "pallet-bounties/try-runtime",
-  "pallet-child-bounties/try-runtime",
-  "pallet-collective/try-runtime",
-  "pallet-contracts/try-runtime",
-  "pallet-democracy/try-runtime",
-  "pallet-identity/try-runtime",
-  "pallet-multisig/try-runtime",
-  "pallet-preimage/try-runtime",
-  "pallet-proxy/try-runtime",
-  "pallet-insecure-randomness-collective-flip/try-runtime",
-  "pallet-scheduler/try-runtime",
-  "pallet-session/try-runtime",
-  "pallet-transaction-payment/try-runtime",
-  "pallet-treasury/try-runtime",
-  "pallet-utility/try-runtime",
-  "pallet-vesting/try-runtime",
-  "pallet-xcm/try-runtime",
-    
-  "parachain-staking/try-runtime",
-
-  "cumulus-pallet-aura-ext/try-runtime",
-  "cumulus-pallet-dmp-queue/try-runtime",
-  "cumulus-pallet-parachain-system/try-runtime",
-  "cumulus-pallet-xcm/try-runtime",
-  "cumulus-pallet-xcmp-queue/try-runtime",
-
-  "orml-asset-registry/try-runtime",
-  "orml-currencies/try-runtime",
-  "orml-tokens/try-runtime",
-  "orml-xtokens/try-runtime",
-
-  "stellar-relay/try-runtime",
-  "issue/try-runtime",
-  "currency/try-runtime",
-  "security/try-runtime",
-  "staking/try-runtime",
-  "oracle/try-runtime",
-  "fee/try-runtime",
-  "vault-registry/try-runtime",
-  "redeem/try-runtime",
-  "nomination/try-runtime",
-  "replace/try-runtime",
-  "pooled-rewards/try-runtime",
-  "clients-info/try-runtime",
-  "reward-distribution/try-runtime",
-
-  "dia-oracle/try-runtime",
-  "orml-currencies-allowance-extension/try-runtime",
-  "vesting-manager/try-runtime",
-    
-  "bifrost-farming/try-runtime",
-
-  "zenlink-protocol/try-runtime",
+    "frame-executive/try-runtime",
+    "frame-try-runtime",
+    "frame-system/try-runtime",
+    "parachain-info/try-runtime",
+    "pallet-timestamp/try-runtime",
+    "pallet-aura/try-runtime",
+    "pallet-authorship/try-runtime",
+    "pallet-balances/try-runtime",
+    "pallet-bounties/try-runtime",
+    "pallet-child-bounties/try-runtime",
+    "pallet-collective/try-runtime",
+    "pallet-contracts/try-runtime",
+    "pallet-democracy/try-runtime",
+    "pallet-identity/try-runtime",
+    "pallet-multisig/try-runtime",
+    "pallet-preimage/try-runtime",
+    "pallet-proxy/try-runtime",
+    "pallet-insecure-randomness-collective-flip/try-runtime",
+    "pallet-scheduler/try-runtime",
+    "pallet-session/try-runtime",
+    "pallet-transaction-payment/try-runtime",
+    "pallet-treasury/try-runtime",
+    "pallet-utility/try-runtime",
+    "pallet-vesting/try-runtime",
+    "pallet-xcm/try-runtime",
+    "parachain-staking/try-runtime",
+    "cumulus-pallet-aura-ext/try-runtime",
+    "cumulus-pallet-dmp-queue/try-runtime",
+    "cumulus-pallet-parachain-system/try-runtime",
+    "cumulus-pallet-xcm/try-runtime",
+    "cumulus-pallet-xcmp-queue/try-runtime",
+    "orml-asset-registry/try-runtime",
+    "orml-currencies/try-runtime",
+    "orml-tokens/try-runtime",
+    "orml-xtokens/try-runtime",
+    "stellar-relay/try-runtime",
+    "issue/try-runtime",
+    "currency/try-runtime",
+    "security/try-runtime",
+    "staking/try-runtime",
+    "oracle/try-runtime",
+    "fee/try-runtime",
+    "vault-registry/try-runtime",
+    "redeem/try-runtime",
+    "nomination/try-runtime",
+    "replace/try-runtime",
+    "pooled-rewards/try-runtime",
+    "clients-info/try-runtime",
+    "reward-distribution/try-runtime",
+    "dia-oracle/try-runtime",
+    "orml-currencies-allowance-extension/try-runtime",
+    "vesting-manager/try-runtime",
+    "bifrost-farming/try-runtime",
+    "zenlink-protocol/try-runtime",
 ]

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -93,6 +93,7 @@ use xcm_config::{XcmConfig, XcmOriginToTransactDispatchOrigin};
 use module_oracle_rpc_runtime_api::BalanceWrapper;
 use orml_currencies::BasicCurrencyAdapter;
 use orml_traits::{currency::MutationHooks, parameter_type_with_key};
+
 const CONTRACTS_DEBUG_OUTPUT: bool = true;
 
 #[cfg(any(feature = "std", test))]
@@ -222,6 +223,7 @@ impl Convert<u64, Option<Moment>> for ConvertMoment {
 ///   - Setting it to `0` will essentially disable the weight fee.
 ///   - Setting it to `1` will cause the literal `#[weight = x]` values to be charged.
 pub struct WeightToFee;
+
 impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
@@ -247,7 +249,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("pendulum"),
 	impl_name: create_runtime_str!("pendulum"),
 	authoring_version: 1,
-	spec_version: 12,
+	spec_version: 13,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 10,
@@ -322,6 +324,7 @@ parameter_types! {
 }
 
 pub struct BaseFilter;
+
 impl Contains<RuntimeCall> for BaseFilter {
 	fn contains(call: &RuntimeCall) -> bool {
 		match call {
@@ -477,6 +480,7 @@ parameter_types! {
 type NegativeImbalance = <Balances as FrameCurrency<AccountId>>::NegativeImbalance;
 
 pub struct DealWithFees;
+
 impl OnUnbalanced<NegativeImbalance> for DealWithFees {
 	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
 		if let Some(mut fees) = fees_then_tips.next() {
@@ -630,6 +634,7 @@ parameter_types! {
 }
 
 type CouncilCollective = pallet_collective::Instance1;
+
 impl pallet_collective::Config<CouncilCollective> for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 	type Proposal = RuntimeCall;
@@ -649,6 +654,7 @@ parameter_types! {
 }
 
 type TechnicalCollective = pallet_collective::Instance2;
+
 impl pallet_collective::Config<TechnicalCollective> for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 	type Proposal = RuntimeCall;
@@ -789,6 +795,7 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
 }
 
 pub struct DustRemovalWhitelist;
+
 impl Contains<AccountId> for DustRemovalWhitelist {
 	fn contains(a: &AccountId) -> bool {
 		get_all_module_accounts().contains(a)
@@ -796,6 +803,7 @@ impl Contains<AccountId> for DustRemovalWhitelist {
 }
 
 pub struct CurrencyHooks<T>(PhantomData<T>);
+
 impl<T: orml_tokens::Config> MutationHooks<T::AccountId, T::CurrencyId, T::Balance>
 	for CurrencyHooks<T>
 {

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -1147,6 +1147,7 @@ impl<K, V, A> orml_traits::DataProvider<K, V> for DataFeederBenchmark<K, V, A> {
 impl oracle::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = oracle::SubstrateWeight<Runtime>;
+	type DecimalsLookup = spacewalk_primitives::PendulumDecimalsLookup;
 	type DataProvider = DataProviderImpl;
 	#[cfg(feature = "runtime-benchmarks")]
 	type DataFeeder = MockDataFeeder<Self::AccountId, Moment>;


### PR DESCRIPTION
<!-- If you added changes to files in the `node` directory or any other changes that would require a re-deployment of the collator nodes, please add the following line to the PR description:
@pendulum-chain/product: This PR adds changes to the node client code that require a **redeployment of the collator nodes** to take effect. 
Please ensure that the collator nodes are redeployed after this PR is merged.  
-->

My IDE automatically changed some things about code formatting and indentation. I can change that back but I think the formatting is better this way. 

- [x] The runtime upgrade was deployed on Foucoco. The compiled runtime is 
[foucoco_runtime.compact.compressed.wasm.zip](https://github.com/pendulum-chain/pendulum/files/14357722/foucoco_runtime.compact.compressed.wasm.zip)
- [x] I tested the pendulum runtime locally in zombienet and it's working fine producing blocks.

The compiled runtimes for pendulum is 
[pendulum_runtime.compact.compressed.wasm.zip](https://github.com/pendulum-chain/pendulum/files/14357747/pendulum_runtime.compact.compressed.wasm.zip)


<!-- Replace xx with the issue number that is fixed by this pull request. -->
Closes #417. 