### PR TITLE
Bump Amplitude `spec_version` to 14

### DIFF
--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -268,7 +268,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("amplitude"),
 	impl_name: create_runtime_str!("amplitude"),
 	authoring_version: 1,
-	spec_version: 13,
+	spec_version: 14,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 13,


### PR DESCRIPTION
<!-- If you added changes to files in the `node` directory or any other changes that would require a re-deployment of the collator nodes, please add the following line to the PR description:
@pendulum-chain/product: This PR adds changes to the node client code that require a **redeployment of the collator nodes** to take effect. 
Please ensure that the collator nodes are redeployed after this PR is merged.  
-->

This PR bumps the Amplitude spec version to prepare the runtime upgrade for the next release.

I tested locally in zombienet and the runtime is working fine. I did not check uploading the runtime with chopsticks.

The compiled runtime is:
[amplitude_runtime.compact.compressed.wasm.zip](https://github.com/pendulum-chain/pendulum/files/14407110/amplitude_runtime.compact.compressed.wasm.zip)


<!-- Replace xx with the issue number that is fixed by this pull request. -->
Related to https://github.com/pendulum-chain/tasks/issues/198. 
