### PR TITLE
bump foucoco spec version

### DIFF
--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -316,7 +316,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("foucoco"),
 	impl_name: create_runtime_str!("foucoco"),
 	authoring_version: 1,
-	spec_version: 10,
+	spec_version: 13,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 8,


### PR DESCRIPTION
Closes #435 . 

Spec version will jump from `10` to `13` since at the moment of writing the on-chain version is `12`.

Compressed wasm used for the upgrade:
[foucoco_runtime.compact.compressed.wasm.zip](https://github.com/pendulum-chain/pendulum/files/14669650/foucoco_runtime.compact.compressed.wasm.zip)

Code hash:
`0xa3da8c50b2b1d469223f80addd1b8a322444ba032712427c13ffd45c9d7a9d10`.