### PR TITLE
422 add treasury buyout extension pallet to pendulum runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8057,6 +8057,7 @@ dependencies = [
  "stellar-relay",
  "substrate-wasm-builder",
  "token-chain-extension",
+ "treasury-buyout-extension",
  "vault-registry",
  "vesting-manager",
  "xcm",

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1485,7 +1485,7 @@ impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
 
 parameter_types! {
 	pub const SellFee: Permill = Permill::from_percent(5);
-	pub const MinAmountToBuyout: Balance = 100 * MILLIUNIT;; // 0.1 AMPE or 100_000_000_000
+	pub const MinAmountToBuyout: Balance = 100 * MILLIUNIT; // 0.1 AMPE or 100_000_000_000
 	// 24 hours in blocks (where average block time is 12 seconds)
 	pub const BuyoutPeriod: u32 = 7200;
 	// Maximum number of allowed currencies for buyout

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1485,7 +1485,7 @@ impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
 
 parameter_types! {
 	pub const SellFee: Permill = Permill::from_percent(5);
-	pub const MinAmountToBuyout: Balance = 10 * MILLIUNIT; // 0.01 AMPE or 10_000_000_000
+	pub const MinAmountToBuyout: Balance = 100 * MILLIUNIT;; // 0.1 AMPE or 100_000_000_000
 	// 24 hours in blocks (where average block time is 12 seconds)
 	pub const BuyoutPeriod: u32 = 7200;
 	// Maximum number of allowed currencies for buyout

--- a/runtime/pendulum/Cargo.toml
+++ b/runtime/pendulum/Cargo.toml
@@ -27,6 +27,7 @@ smallvec = "1.9.0"
 runtime-common = { path = "../common", default-features = false }
 token-chain-extension = {path = "../../chain-extensions/token", default-features = false }
 price-chain-extension = {path = "../../chain-extensions/price", default-features = false }
+treasury-buyout-extension = {path = "../../pallets/treasury-buyout-extension", default-features = false}
 
 # Custom libraries for Spacewalk
 clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
@@ -245,6 +246,7 @@ std = [
     "vesting-manager/std",
     "price-chain-extension/std",
     "token-chain-extension/std",
+    "treasury-buyout-extension/std",
 ]
 
 runtime-benchmarks = [
@@ -271,6 +273,7 @@ runtime-benchmarks = [
     "pallet-collective/runtime-benchmarks",
     "runtime-common/runtime-benchmarks",
     "orml-currencies-allowance-extension/runtime-benchmarks",
+    "treasury-buyout-extension/runtime-benchmarks",
 ]
 
 try-runtime = [
@@ -328,4 +331,5 @@ try-runtime = [
     "vesting-manager/try-runtime",
     "bifrost-farming/try-runtime",
     "zenlink-protocol/try-runtime",
+    "treasury-buyout-extension/try-runtime",
 ]

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -42,6 +42,12 @@ use spacewalk_primitives::{
 	UnsignedInner,
 };
 
+use oracle::{
+	dia,
+	dia::{DiaOracleAdapter, NativeCurrencyKey, XCMCurrencyConversion},
+	OracleKey,
+};
+
 #[cfg(any(feature = "runtime-benchmarks", feature = "testing-utils"))]
 use oracle::testing_utils::MockDataFeeder;
 
@@ -139,6 +145,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	treasury_buyout_extension::CheckBuyout<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.
@@ -1150,6 +1157,7 @@ where
 			frame_system::CheckNonce::<Runtime>::from(index),
 			frame_system::CheckWeight::<Runtime>::new(),
 			pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
+			treasury_buyout_extension::CheckBuyout<Runtime>,
 		);
 
 		let raw_payload = SignedPayload::new(call, extra).ok()?;
@@ -1390,6 +1398,82 @@ impl orml_currencies_allowance_extension::Config for Runtime {
 	type WeightInfo =
 		orml_currencies_allowance_extension::default_weights::SubstrateWeight<Runtime>;
 	type MaxAllowedCurrencies = ConstU32<256>;
+}
+
+pub struct OraclePriceGetter(Oracle);
+
+impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
+	#[cfg(not(feature = "runtime-benchmarks"))]
+	fn get_price<FixedNumber>(currency_id: CurrencyId) -> Result<FixedNumber, DispatchError>
+	where
+		FixedNumber: FixedPointNumber + One + Zero + Debug + TryFrom<FixedU128>,
+	{
+		let key = OracleKey::ExchangeRate(currency_id);
+		let asset_price = Oracle::get_price(key.clone())?;
+
+		let converted_asset_price = FixedNumber::try_from(asset_price);
+
+		match converted_asset_price {
+			Ok(price) => Ok(price),
+			Err(_) => Err(DispatchError::Other("Failed to convert price")),
+		}
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn get_price<FixedNumber>(currency_id: CurrencyId) -> Result<FixedNumber, DispatchError>
+	where
+		FixedNumber: FixedPointNumber + One + Zero + Debug + TryFrom<FixedU128>,
+	{
+		// Forcefully set chain status to running when benchmarking so that the oracle doesn't fail
+		Security::set_status(StatusCode::Running);
+
+		let key = OracleKey::ExchangeRate(currency_id);
+
+		// Attempt to get the price once and use the result to decide if feeding a value is necessary
+		match Oracle::get_price(key.clone()) {
+			Ok(asset_price) => {
+				// If the price is successfully retrieved, use it directly
+				let converted_asset_price = FixedNumber::try_from(asset_price)
+					.map_err(|_| DispatchError::Other("Failed to convert price"))?;
+				Ok(converted_asset_price)
+			},
+			Err(_) => {
+				// Price not found, feed the default value
+				let rate = FixedU128::checked_from_rational(100, 1).expect("This is a valid ratio");
+				// Account used for feeding values
+				let account = AccountId::from([0u8; 32]);
+				Oracle::feed_values(account, vec![(key.clone(), rate)])?;
+
+				// If feeding was successful, just use the feeded price to spare a read
+				let converted_asset_price = FixedNumber::try_from(rate)
+					.map_err(|_| DispatchError::Other("Failed to convert price"))?;
+				Ok(converted_asset_price)
+			},
+		}
+	}
+}
+
+parameter_types! {
+	pub const SellFee: Permill = Permill::from_percent(5);
+	pub const MinAmountToBuyout: Balance = 100 * MILLIUNIT; // 0.1 PEN or 100_000_000_000
+	// 24 hours in blocks (where average block time is 12 seconds)
+	pub const BuyoutPeriod: u32 = 7200;
+	// Maximum number of allowed currencies for buyout
+	pub const MaxAllowedBuyoutCurrencies: u32 = 20;
+}
+
+impl treasury_buyout_extension::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Currencies;
+	type TreasuryAccount = PendulumTreasuryAccount;
+	type BuyoutPeriod = BuyoutPeriod;
+	type SellFee = SellFee;
+	type PriceGetter = OraclePriceGetter;
+	type MinAmountToBuyout = MinAmountToBuyout;
+	type MaxAllowedBuyoutCurrencies = MaxAllowedBuyoutCurrencies;
+	type WeightInfo = treasury_buyout_extension::default_weights::SubstrateWeight<Runtime>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type RelayChainCurrencyId = RelayChainCurrencyId;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.


### PR DESCRIPTION
Closes #422. 

This PR adds the Buyout Pallet to the Pendulum runtime, with the constants as defined by the issue. We also modify Amplitude's `MinAmountToBuyout` to `0.1` AMPE.