### PR TITLE
460 take token decimals into account for price conversions in treasury buyout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "spacewalk-primitives 1.0.7",
+ "spacewalk-primitives",
  "staking",
  "stellar-relay",
  "substrate-wasm-builder",
@@ -1257,8 +1257,8 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clients-info"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2158,8 +2158,8 @@ dependencies = [
 
 [[package]]
 name = "currency"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2173,7 +2173,7 @@ dependencies = [
  "serde",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
 ]
 
 [[package]]
@@ -2950,8 +2950,8 @@ dependencies = [
 
 [[package]]
 name = "fee"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -2970,7 +2970,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
  "staking",
 ]
 
@@ -3208,7 +3208,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "spacewalk-primitives 1.0.7",
+ "spacewalk-primitives",
  "staking",
  "stellar-relay",
  "substrate-wasm-builder",
@@ -3637,6 +3637,10 @@ name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -3771,6 +3775,51 @@ dependencies = [
  "fnv",
  "log",
  "regex",
+]
+
+[[package]]
+name = "gloo-net"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9902a044653b26b99f7e3693a42f171312d9be8b26b5697bd1e43ad1f8a35e10"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4306,8 +4355,8 @@ dependencies = [
 
 [[package]]
 name = "issue"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -4334,7 +4383,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
  "stellar-relay",
  "vault-registry",
 ]
@@ -4378,11 +4427,13 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
 dependencies = [
+ "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
+ "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "tracing",
 ]
@@ -4393,7 +4444,11 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965de52763f2004bc91ac5bcec504192440f0b568a5d621c59d9dbd6f886c3fb"
 dependencies = [
+ "anyhow",
+ "futures-channel",
+ "futures-timer",
  "futures-util",
+ "gloo-net",
  "http",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -4434,6 +4489,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -4502,6 +4558,17 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-wasm-client"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77310456f43c6c89bcba1f6b2fc2a28300da7c341f320f5128f8c83cc63232d"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -5612,8 +5679,8 @@ dependencies = [
 
 [[package]]
 name = "module-issue-rpc"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "jsonrpsee",
  "module-issue-rpc-runtime-api",
@@ -5625,8 +5692,8 @@ dependencies = [
 
 [[package]]
 name = "module-issue-rpc-runtime-api"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5636,8 +5703,8 @@ dependencies = [
 
 [[package]]
 name = "module-oracle-rpc"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5645,13 +5712,13 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
 ]
 
 [[package]]
 name = "module-oracle-rpc-runtime-api"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5659,7 +5726,7 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
 ]
 
 [[package]]
@@ -5690,8 +5757,8 @@ dependencies = [
 
 [[package]]
 name = "module-redeem-rpc"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "jsonrpsee",
  "module-redeem-rpc-runtime-api",
@@ -5703,8 +5770,8 @@ dependencies = [
 
 [[package]]
 name = "module-redeem-rpc-runtime-api"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5714,8 +5781,8 @@ dependencies = [
 
 [[package]]
 name = "module-replace-rpc"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "jsonrpsee",
  "module-replace-rpc-runtime-api",
@@ -5727,8 +5794,8 @@ dependencies = [
 
 [[package]]
 name = "module-replace-rpc-runtime-api"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5738,8 +5805,8 @@ dependencies = [
 
 [[package]]
 name = "module-vault-registry-rpc"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -5752,8 +5819,8 @@ dependencies = [
 
 [[package]]
 name = "module-vault-registry-rpc-runtime-api"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "frame-support",
  "module-oracle-rpc-runtime-api",
@@ -6027,8 +6094,8 @@ dependencies = [
 
 [[package]]
 name = "nomination"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "currency",
  "fee",
@@ -6052,7 +6119,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
  "staking",
  "vault-registry",
 ]
@@ -6205,8 +6272,8 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "oracle"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "currency",
  "dia-oracle",
@@ -6225,7 +6292,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
  "spin 0.9.8",
  "staking",
 ]
@@ -6399,7 +6466,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.7",
+ "spacewalk-primitives",
 ]
 
 [[package]]
@@ -7945,7 +8012,7 @@ dependencies = [
  "sp-session",
  "sp-timestamp",
  "sp-transaction-pool",
- "spacewalk-primitives 1.0.7",
+ "spacewalk-primitives",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
@@ -8052,7 +8119,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "spacewalk-primitives 1.0.7",
+ "spacewalk-primitives",
  "staking",
  "stellar-relay",
  "substrate-wasm-builder",
@@ -9425,10 +9492,9 @@ dependencies = [
 
 [[package]]
 name = "pooled-rewards"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
- "currency",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -9441,7 +9507,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
 ]
 
 [[package]]
@@ -9513,7 +9579,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "spacewalk-primitives 1.0.7",
+ "spacewalk-primitives",
  "vesting-manager",
 ]
 
@@ -9907,8 +9973,8 @@ dependencies = [
 
 [[package]]
 name = "redeem"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "currency",
  "fee",
@@ -9932,7 +9998,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
  "stellar-relay",
  "vault-registry",
 ]
@@ -10069,8 +10135,8 @@ dependencies = [
 
 [[package]]
 name = "replace"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "currency",
  "fee",
@@ -10096,7 +10162,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
  "stellar-relay",
  "vault-registry",
 ]
@@ -10113,8 +10179,8 @@ dependencies = [
 
 [[package]]
 name = "reward"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10127,13 +10193,13 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
 ]
 
 [[package]]
 name = "reward-distribution"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -10155,7 +10221,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
  "staking",
 ]
 
@@ -10385,7 +10451,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.7",
+ "spacewalk-primitives",
  "xcm",
  "xcm-executor",
  "zenlink-protocol",
@@ -10432,7 +10498,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-tracing",
- "spacewalk-primitives 1.0.7",
+ "spacewalk-primitives",
  "statemine-runtime",
  "statemint-runtime",
  "xcm",
@@ -11927,8 +11993,8 @@ dependencies = [
 
 [[package]]
 name = "security"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11996,6 +12062,12 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
@@ -12986,26 +13058,8 @@ dependencies = [
 
 [[package]]
 name = "spacewalk-primitives"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
-dependencies = [
- "base58",
- "bstringify",
- "frame-support",
- "hex",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime",
- "sp-std",
- "substrate-stellar-sdk",
-]
-
-[[package]]
-name = "spacewalk-primitives"
 version = "1.0.7"
-source = "git+https://github.com/pendulum-chain/spacewalk?branch=522-modify-decimalslookup-trait-to-use-its-own-currencyid-type#e63db542e7c6936a50a2868605d5731e9e0c2f8d"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "base58",
  "bstringify",
@@ -13089,8 +13143,8 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staking"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13105,7 +13159,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
 ]
 
 [[package]]
@@ -13297,8 +13351,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-relay"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "base64 0.13.1",
  "currency",
@@ -13311,7 +13365,7 @@ dependencies = [
  "sha2 0.10.7",
  "sp-core",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
 ]
 
 [[package]]
@@ -13770,7 +13824,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.7",
+ "spacewalk-primitives",
 ]
 
 [[package]]
@@ -14061,7 +14115,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.7",
+ "spacewalk-primitives",
  "xcm",
 ]
 
@@ -14342,8 +14396,8 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vault-registry"
-version = "1.0.5"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=3c03e759a6f600ea72d636d4f9cc4b05d633201c#3c03e759a6f600ea72d636d4f9cc4b05d633201c"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=e7a672ba1e21c98a70df30a6ee458317951dd597#e7a672ba1e21c98a70df30a6ee458317951dd597"
 dependencies = [
  "currency",
  "fee",
@@ -14370,7 +14424,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives 1.0.5",
+ "spacewalk-primitives",
  "staking",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.7",
  "staking",
  "stellar-relay",
  "substrate-wasm-builder",
@@ -2173,7 +2173,7 @@ dependencies = [
  "serde",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
 ]
 
 [[package]]
@@ -2970,7 +2970,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
  "staking",
 ]
 
@@ -3208,7 +3208,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.7",
  "staking",
  "stellar-relay",
  "substrate-wasm-builder",
@@ -4334,7 +4334,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
  "stellar-relay",
  "vault-registry",
 ]
@@ -5645,7 +5645,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
 ]
 
 [[package]]
@@ -5659,7 +5659,7 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
 ]
 
 [[package]]
@@ -6052,7 +6052,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
  "staking",
  "vault-registry",
 ]
@@ -6225,7 +6225,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
  "spin 0.9.8",
  "staking",
 ]
@@ -6399,7 +6399,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.7",
 ]
 
 [[package]]
@@ -7945,7 +7945,7 @@ dependencies = [
  "sp-session",
  "sp-timestamp",
  "sp-transaction-pool",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.7",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
@@ -8052,7 +8052,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.7",
  "staking",
  "stellar-relay",
  "substrate-wasm-builder",
@@ -9441,7 +9441,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
 ]
 
 [[package]]
@@ -9513,7 +9513,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.7",
  "vesting-manager",
 ]
 
@@ -9932,7 +9932,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
  "stellar-relay",
  "vault-registry",
 ]
@@ -10096,7 +10096,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
  "stellar-relay",
  "vault-registry",
 ]
@@ -10127,7 +10127,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
 ]
 
 [[package]]
@@ -10155,7 +10155,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
  "staking",
 ]
 
@@ -10385,7 +10385,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.7",
  "xcm",
  "xcm-executor",
  "zenlink-protocol",
@@ -10432,7 +10432,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-tracing",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.7",
  "statemine-runtime",
  "statemint-runtime",
  "xcm",
@@ -13003,6 +13003,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "spacewalk-primitives"
+version = "1.0.7"
+source = "git+https://github.com/pendulum-chain/spacewalk?branch=522-modify-decimalslookup-trait-to-use-its-own-currencyid-type#e63db542e7c6936a50a2868605d5731e9e0c2f8d"
+dependencies = [
+ "base58",
+ "bstringify",
+ "frame-support",
+ "hex",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+ "substrate-stellar-sdk",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13087,7 +13105,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
 ]
 
 [[package]]
@@ -13293,7 +13311,7 @@ dependencies = [
  "sha2 0.10.7",
  "sp-core",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
 ]
 
 [[package]]
@@ -13752,7 +13770,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.7",
 ]
 
 [[package]]
@@ -14027,12 +14045,14 @@ dependencies = [
  "frame-support",
  "frame-system",
  "mocktopus",
+ "orml-asset-registry",
  "orml-currencies",
  "orml-tokens 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.42)",
  "orml-traits",
  "pallet-balances",
  "pallet-treasury",
  "parity-scale-codec",
+ "runtime-common",
  "scale-info",
  "serde",
  "sha2 0.8.2",
@@ -14041,7 +14061,8 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.7",
+ "xcm",
 ]
 
 [[package]]
@@ -14349,7 +14370,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spacewalk-primitives",
+ "spacewalk-primitives 1.0.5",
  "staking",
 ]
 

--- a/chain-extensions/price/Cargo.toml
+++ b/chain-extensions/price/Cargo.toml
@@ -21,7 +21,7 @@ frame-system = { git = "https://github.com/paritytech/substrate", default-featur
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 pallet-contracts = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 
 # Open Runtime Module Library
 orml-currencies = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.42" }

--- a/chain-extensions/price/Cargo.toml
+++ b/chain-extensions/price/Cargo.toml
@@ -21,7 +21,7 @@ frame-system = { git = "https://github.com/paritytech/substrate", default-featur
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 pallet-contracts = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
 
 # Open Runtime Module Library
 orml-currencies = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.42" }

--- a/chain-extensions/token/Cargo.toml
+++ b/chain-extensions/token/Cargo.toml
@@ -27,7 +27,7 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.42" }
 
 # Custom libraries for Spacewalk
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
 
 # Pendulum Pallets
 orml-currencies-allowance-extension = { path = "../../pallets/orml-currencies-allowance-extension", default-features = false }

--- a/chain-extensions/token/Cargo.toml
+++ b/chain-extensions/token/Cargo.toml
@@ -27,7 +27,7 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.42" }
 
 # Custom libraries for Spacewalk
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 
 # Pendulum Pallets
 orml-currencies-allowance-extension = { path = "../../pallets/orml-currencies-allowance-extension", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -21,7 +21,7 @@ module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =
 module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c"}
 module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c"}
 module-pallet-staking-rpc = { path = "../pallets/parachain-staking/rpc" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
 
 # Local
 amplitude-runtime = { path = "../runtime/amplitude" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,13 +15,13 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.145", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 
-module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c"}
-module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c"}
-module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c"}
-module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c"}
-module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c"}
+module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 module-pallet-staking-rpc = { path = "../pallets/parachain-staking/rpc" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 
 # Local
 amplitude-runtime = { path = "../runtime/amplitude" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -21,7 +21,7 @@ module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev =
 module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 module-pallet-staking-rpc = { path = "../pallets/parachain-staking/rpc" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 
 # Local
 amplitude-runtime = { path = "../runtime/amplitude" }

--- a/pallets/orml-tokens-management-extension/Cargo.toml
+++ b/pallets/orml-tokens-management-extension/Cargo.toml
@@ -33,7 +33,7 @@ sp-io = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.
 pallet-balances = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42"}
 
 # Spacewalk libraries
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 
 
 [features]

--- a/pallets/orml-tokens-management-extension/Cargo.toml
+++ b/pallets/orml-tokens-management-extension/Cargo.toml
@@ -33,7 +33,7 @@ sp-io = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.
 pallet-balances = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42"}
 
 # Spacewalk libraries
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
 
 
 [features]

--- a/pallets/parachain-staking/rpc/Cargo.toml
+++ b/pallets/parachain-staking/rpc/Cargo.toml
@@ -7,7 +7,7 @@ version = "1.0.0"
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.0.0"}
 jsonrpsee = {version = "0.16.0", features = ["server", "macros"]}
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c"}
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 module-pallet-staking-rpc-runtime-api = {path = "runtime-api"}
 sp-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42"}
 sp-blockchain = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42"}

--- a/pallets/parachain-staking/rpc/runtime-api/Cargo.toml
+++ b/pallets/parachain-staking/rpc/runtime-api/Cargo.toml
@@ -10,7 +10,7 @@ sp-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0
 sp-std = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false}
 parity-scale-codec = {version = "3.1.5", default-features = false, features = ["derive"]}
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c"}
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 serde = {version = "1.0.142", default-features = false, optional = true, features = ["derive"]}
 
 [features]

--- a/pallets/treasury-buyout-extension/Cargo.toml
+++ b/pallets/treasury-buyout-extension/Cargo.toml
@@ -26,7 +26,7 @@ orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.42", default-features = false }
 orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.42", default-features = false }
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 
 [dev-dependencies]
 mocktopus = "0.8.0"
@@ -36,7 +36,7 @@ xcm = { git = "https://github.com/paritytech/polkadot", default-features = false
 
 pallet-balances = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42"}
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 runtime-common = { path = "../../runtime/common", default-features = false }
 
 [features]
@@ -54,16 +54,20 @@ std = [
   "orml-currencies/std",
   "orml-tokens/std",
   "orml-traits/std",
+  "orml-asset-registry/std",
   "frame-benchmarking/std",
   "pallet-balances/std",
-  "spacewalk-primitives/std"
+  "spacewalk-primitives/std",
+  "xcm/std",
+  "runtime-common/std"
 ]
 
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
-    "pallet-balances/runtime-benchmarks"
+    "pallet-balances/runtime-benchmarks",
+    "runtime-common/runtime-benchmarks"
 ]
 
 try-runtime = [
@@ -71,5 +75,6 @@ try-runtime = [
     "frame-system/try-runtime",
     "orml-currencies/try-runtime",
     "orml-tokens/try-runtime",
+    "orml-asset-registry/try-runtime",
     "pallet-balances/try-runtime"
 ]

--- a/pallets/treasury-buyout-extension/Cargo.toml
+++ b/pallets/treasury-buyout-extension/Cargo.toml
@@ -24,15 +24,20 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch =
 orml-currencies = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.42", default-features = false }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.42", default-features = false }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.42", default-features = false }
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.42", default-features = false }
+
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
 
 [dev-dependencies]
 mocktopus = "0.8.0"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
 sp-io = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false}
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.42" }
 
 pallet-balances = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42"}
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
+runtime-common = { path = "../../runtime/common", default-features = false }
 
 [features]
 default = ["std"]

--- a/pallets/treasury-buyout-extension/src/lib.rs
+++ b/pallets/treasury-buyout-extension/src/lib.rs
@@ -346,7 +346,7 @@ impl<T: Config> Pallet<T> {
 			.ok_or::<DispatchError>(ArithmeticError::Overflow.into())?;
 		let basic_asset_price_with_fee = basic_asset_price.saturating_mul(fee_plus_one);
 
-		// Calculate buyout amount taking into consideration assets' prices and decimals
+		// Calculate exchange amount taking into consideration assets' prices and decimals
 		let exchange_amount = Self::convert_amount(
 			buyout_amount,
 			basic_asset_price_with_fee,

--- a/pallets/treasury-buyout-extension/src/lib.rs
+++ b/pallets/treasury-buyout-extension/src/lib.rs
@@ -29,18 +29,16 @@ use frame_support::{
 };
 use orml_traits::MultiCurrency;
 pub use pallet::*;
-use sp_arithmetic::{
-	per_things::Rounding,
-	traits::{CheckedAdd, Saturating},
-};
+use sp_arithmetic::traits::{CheckedAdd, CheckedMul, CheckedDiv, Saturating};
 use sp_runtime::{
-	traits::{DispatchInfoOf, One, SignedExtension, Zero},
+	traits::{DispatchInfoOf, One, SignedExtension, UniqueSaturatedInto, Zero},
 	transaction_validity::{
 		InvalidTransaction, TransactionValidity, TransactionValidityError, ValidTransaction,
 	},
 	ArithmeticError, FixedPointNumber, FixedU128,
 };
 use sp_std::{fmt::Debug, marker::PhantomData, vec::Vec};
+use spacewalk_primitives::DecimalsLookup;
 
 pub use pallet::*;
 
@@ -73,6 +71,9 @@ pub mod pallet {
 
 		/// Used for fetching prices of currencies from oracle
 		type PriceGetter: PriceGetter<CurrencyIdOf<Self>>;
+
+		/// Used for fetching decimals of assets
+		type DecimalsLookup: DecimalsLookup<CurrencyId = CurrencyIdOf<Self>>;
 
 		/// Min amount of native token to buyout
 		#[pallet::constant]
@@ -117,6 +118,8 @@ pub mod pallet {
 		BuyoutWithTreasuryAccount,
 		/// Exchange failed
 		ExchangeFailure,
+		/// Decimals conversion error
+		DecimalsConversionError,
 	}
 
 	#[pallet::event]
@@ -343,14 +346,14 @@ impl<T: Config> Pallet<T> {
 			.ok_or::<DispatchError>(ArithmeticError::Overflow.into())?;
 		let basic_asset_price_with_fee = basic_asset_price.saturating_mul(fee_plus_one);
 
-		let exchange_amount = Self::multiply_by_rational(
-			buyout_amount.saturated_into::<u128>(),
-			basic_asset_price_with_fee.into_inner(),
-			exchange_asset_price.into_inner(),
-		)
-		.map(|n| n.try_into().ok())
-		.flatten()
-		.ok_or(ArithmeticError::Overflow.into());
+		// Calculate buyout amount taking into consideration assets' prices and decimals
+		let exchange_amount = Self::convert_amount(
+			buyout_amount,
+			basic_asset_price_with_fee,
+			exchange_asset_price,
+			T::DecimalsLookup::decimals(basic_asset),
+			T::DecimalsLookup::decimals(asset),
+		);
 
 		exchange_amount
 	}
@@ -372,14 +375,14 @@ impl<T: Config> Pallet<T> {
 			.ok_or::<DispatchError>(ArithmeticError::Overflow.into())?;
 		let basic_asset_price_with_fee = basic_asset_price.saturating_mul(fee_plus_one);
 
-		let buyout_amount = Self::multiply_by_rational(
-			exchange_amount.saturated_into::<u128>(),
-			exchange_asset_price.into_inner(),
-			basic_asset_price_with_fee.into_inner(),
-		)
-		.map(|b| b.try_into().ok())
-		.flatten()
-		.ok_or(ArithmeticError::Overflow.into());
+		// Calculate buyout amount taking into consideration assets' prices and decimals
+		let buyout_amount = Self::convert_amount(
+			exchange_amount,
+			exchange_asset_price,
+			basic_asset_price_with_fee,
+			T::DecimalsLookup::decimals(asset),
+			T::DecimalsLookup::decimals(basic_asset),
+		);
 
 		buyout_amount
 	}
@@ -448,22 +451,6 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	/// Used for calculating exchange amount based on buyout amount(a), price of basic asset with fee(b) and price of exchange asset(c)
-	/// or buyout amount based on exchange amount(a), price of exchange asset(b) and price of basic asset with fee(c)
-	fn multiply_by_rational(
-		a: impl Into<u128>,
-		b: impl Into<u128>,
-		c: impl Into<u128>,
-	) -> Option<u128> {
-		// return a * b / c
-		sp_runtime::helpers_128bit::multiply_by_rational_with_rounding(
-			a.into(),
-			b.into(),
-			c.into(),
-			Rounding::NearestPrefDown,
-		)
-	}
-
 	/// Used for fetching asset prices
 	/// The concrete implementation of PriceGetter trait must be provided by the runtime e.g. oracle pallet
 	fn fetch_prices(
@@ -476,6 +463,59 @@ impl<T: Config> Pallet<T> {
 			.map_err(|_| Error::<T>::NoPrice)?
 			.into();
 		Ok((basic_asset_price, exchange_asset_price))
+	}
+
+	/// Used for converting amount from one asset to another based on their decimals and prices
+	fn convert_amount(
+		from_amount: BalanceOf<T>,
+		from_price: FixedU128,
+		to_price: FixedU128,
+		from_decimals: u32,
+		to_decimals: u32,
+	) -> Result<BalanceOf<T>, DispatchError> {
+		if from_amount.is_zero() {
+			return Ok(Zero::zero())
+		}
+
+		let from_amount = FixedU128::from_inner(from_amount.saturated_into::<u128>());
+
+		if from_decimals > to_decimals {
+			// result = from_amount * from_price / to_price / 10^(from_decimals - to_decimals)
+			let to_amount = from_price
+				.checked_mul(&from_amount)
+				.ok_or(ArithmeticError::Overflow)?
+				.checked_div(&to_price)
+				.ok_or(ArithmeticError::Underflow)?
+				.checked_div(
+					&FixedU128::checked_from_integer(
+						10u128.pow(from_decimals.saturating_sub(to_decimals)),
+					)
+					.ok_or(Error::<T>::DecimalsConversionError)?,
+				)
+				.ok_or(ArithmeticError::Underflow)?
+				.into_inner()
+				.unique_saturated_into();
+
+			Ok(to_amount)
+		} else {
+			// result = from_amount * from_price * 10^(to_decimals - from_decimals) / to_price
+			let to_amount = from_price
+				.checked_mul(&from_amount)
+				.ok_or(ArithmeticError::Overflow)?
+				.checked_mul(
+					&FixedU128::checked_from_integer(
+						10u128.pow(to_decimals.saturating_sub(from_decimals)),
+					)
+					.ok_or(Error::<T>::DecimalsConversionError)?,
+				)
+				.ok_or(ArithmeticError::Overflow)?
+				.checked_div(&to_price)
+				.ok_or(ArithmeticError::Underflow)?
+				.into_inner()
+				.unique_saturated_into();
+
+			Ok(to_amount)
+		}
 	}
 }
 

--- a/pallets/treasury-buyout-extension/src/mock.rs
+++ b/pallets/treasury-buyout-extension/src/mock.rs
@@ -287,8 +287,11 @@ impl Config for Test {
 
 pub const USER: u64 = 0;
 pub const TREASURY_ACCOUNT: u64 = TreasuryAccount::get();
-
-pub const USERS_INITIAL_BALANCE: u128 = 200 * UNIT;
+// Initial balance of 200 native token
+pub const USERS_INITIAL_NATIVE_BALANCE: u128 = 200 * UNIT;
+// Initial balance of 200 DOT
+pub const USERS_INITIAL_DOT_BALANCE: u128 = 2 * UNIT;
+// Initial balance of 1000 native token
 pub const TREASURY_INITIAL_BALANCE: u128 = 1000 * UNIT;
 
 pub struct ExtBuilder;
@@ -300,14 +303,14 @@ impl ExtBuilder {
 		let dot_currency_id = RelayChainCurrencyId::get();
 
 		orml_tokens::GenesisConfig::<Test> {
-			balances: vec![(USER, dot_currency_id, USERS_INITIAL_BALANCE)],
+			balances: vec![(USER, dot_currency_id, USERS_INITIAL_DOT_BALANCE)],
 		}
 		.assimilate_storage(&mut storage)
 		.unwrap();
 
 		pallet_balances::GenesisConfig::<Test> {
 			balances: vec![
-				(USER, USERS_INITIAL_BALANCE),
+				(USER, USERS_INITIAL_NATIVE_BALANCE),
 				(TREASURY_ACCOUNT, TREASURY_INITIAL_BALANCE),
 			],
 		}

--- a/pallets/treasury-buyout-extension/src/mock.rs
+++ b/pallets/treasury-buyout-extension/src/mock.rs
@@ -249,9 +249,7 @@ impl DecimalsLookup for DecimalsLookupImpl {
 		match currency_id {
 			0 => 10,
 			1 => 6,
-			2 => 18,
-			6 => 18,
-			x if x == GetNativeCurrencyId::get() => 12,
+			2 | 6 => 18,
 			_ => 12,
 		}
 	}

--- a/pallets/treasury-buyout-extension/src/tests.rs
+++ b/pallets/treasury-buyout-extension/src/tests.rs
@@ -38,8 +38,8 @@ fn buyout_using_dot_given_exchange_amount_in_dot_succeeds() {
 		assert_eq!(initial_user_native_balance, USERS_INITIAL_NATIVE_BALANCE);
 		assert_eq!(initial_treasury_native_balance, TREASURY_INITIAL_BALANCE);
 		
-		// 100 DOT
-		let exchange_amount = 1 * UNIT;
+		// DOT has 10 decimals
+		let exchange_amount = 100_0000000000;
 		assert_ok!(crate::Pallet::<Test>::buyout(
 			RuntimeOrigin::signed(user),
 			dot_currency_id,
@@ -214,8 +214,8 @@ fn root_update_allowed_currencies_succeeds() {
 		// Test user buyout after allowed currencies update
 		// It should fail because dot is not allowed for buyout
 		let user = USER;
-		// 100 DOT
-		let exchange_amount = 1 * UNIT;
+		// DOT has 10 decimals
+		let exchange_amount = 100_0000000000;
 
 		assert_noop!(
 			crate::Pallet::<Test>::buyout(
@@ -338,7 +338,8 @@ fn attempt_buyout_with_wrong_currency_fails() {
 		assert_eq!(initial_user_native_balance, USERS_INITIAL_NATIVE_BALANCE);
 		assert_eq!(initial_treasury_native_balance, TREASURY_INITIAL_BALANCE);
 
-		let exchange_amount = 1 * UNIT;
+		// DOT has 10 decimals
+		let exchange_amount = 100_0000000000;
 		assert_noop!(
 			crate::Pallet::<Test>::buyout(
 				RuntimeOrigin::signed(user),
@@ -358,8 +359,8 @@ fn buyout_with_previous_existing_buyouts_succeeds() {
 	run_test(|| {
 		let user = USER;
 		let dot_currency_id = RelayChainCurrencyId::get();
-		// 100 DOT
-		let exchange_amount = 1 * UNIT;
+		// DOT has 10 decimals
+		let exchange_amount = 100_0000000000;
 
 		// With buyout limit and buyouts of previous periods
 		BuyoutLimit::<Test>::put(200 * UNIT);
@@ -378,7 +379,8 @@ fn attempt_buyout_after_buyout_limit_exceeded_fails() {
 	run_test(|| {
 		let user = USER;
 		let dot_currency_id = RelayChainCurrencyId::get();
-		let exchange_amount = 1 * UNIT;
+		// DOT has 10 decimals
+		let exchange_amount = 100_0000000000;
 
 		let current_block = frame_system::Pallet::<Test>::block_number().saturated_into::<u32>();
 

--- a/pallets/treasury-buyout-extension/src/tests.rs
+++ b/pallets/treasury-buyout-extension/src/tests.rs
@@ -35,10 +35,11 @@ fn buyout_using_dot_given_exchange_amount_in_dot_succeeds() {
 		let initial_treasury_native_balance =
 			get_free_balance(native_currency_id, &TreasuryAccount::get());
 
-		assert_eq!(initial_user_native_balance, USERS_INITIAL_BALANCE);
+		assert_eq!(initial_user_native_balance, USERS_INITIAL_NATIVE_BALANCE);
 		assert_eq!(initial_treasury_native_balance, TREASURY_INITIAL_BALANCE);
-
-		let exchange_amount = 100 * UNIT;
+		
+		// 100 DOT
+		let exchange_amount = 1 * UNIT;
 		assert_ok!(crate::Pallet::<Test>::buyout(
 			RuntimeOrigin::signed(user),
 			dot_currency_id,
@@ -105,7 +106,7 @@ fn buyout_using_dot_given_buyout_amount_in_native_succeeds() {
 		let initial_treasury_native_balance =
 			get_free_balance(native_currency_id, &TreasuryAccount::get());
 
-		assert_eq!(initial_user_native_balance, USERS_INITIAL_BALANCE);
+		assert_eq!(initial_user_native_balance, USERS_INITIAL_NATIVE_BALANCE);
 		assert_eq!(initial_treasury_native_balance, TREASURY_INITIAL_BALANCE);
 
 		let buyout_amount = 100 * UNIT;
@@ -213,7 +214,8 @@ fn root_update_allowed_currencies_succeeds() {
 		// Test user buyout after allowed currencies update
 		// It should fail because dot is not allowed for buyout
 		let user = USER;
-		let exchange_amount = 100 * UNIT;
+		// 100 DOT
+		let exchange_amount = 1 * UNIT;
 
 		assert_noop!(
 			crate::Pallet::<Test>::buyout(
@@ -320,7 +322,7 @@ fn attempt_buyout_with_wrong_currency_fails() {
 		let initial_treasury_native_balance =
 			get_free_balance(native_currency_id, &TreasuryAccount::get());
 
-		assert_eq!(initial_user_native_balance, USERS_INITIAL_BALANCE);
+		assert_eq!(initial_user_native_balance, USERS_INITIAL_NATIVE_BALANCE);
 		assert_eq!(initial_treasury_native_balance, TREASURY_INITIAL_BALANCE);
 
 		let buyout_amount = 100 * UNIT;
@@ -333,10 +335,10 @@ fn attempt_buyout_with_wrong_currency_fails() {
 			Error::<Test>::WrongAssetToBuyout
 		);
 
-		assert_eq!(initial_user_native_balance, USERS_INITIAL_BALANCE);
+		assert_eq!(initial_user_native_balance, USERS_INITIAL_NATIVE_BALANCE);
 		assert_eq!(initial_treasury_native_balance, TREASURY_INITIAL_BALANCE);
 
-		let exchange_amount = 100 * UNIT;
+		let exchange_amount = 1 * UNIT;
 		assert_noop!(
 			crate::Pallet::<Test>::buyout(
 				RuntimeOrigin::signed(user),
@@ -346,7 +348,7 @@ fn attempt_buyout_with_wrong_currency_fails() {
 			Error::<Test>::WrongAssetToBuyout
 		);
 
-		assert_eq!(initial_user_native_balance, USERS_INITIAL_BALANCE);
+		assert_eq!(initial_user_native_balance, USERS_INITIAL_NATIVE_BALANCE);
 		assert_eq!(initial_treasury_native_balance, TREASURY_INITIAL_BALANCE);
 	});
 }
@@ -356,7 +358,8 @@ fn buyout_with_previous_existing_buyouts_succeeds() {
 	run_test(|| {
 		let user = USER;
 		let dot_currency_id = RelayChainCurrencyId::get();
-		let exchange_amount = 100 * UNIT;
+		// 100 DOT
+		let exchange_amount = 1 * UNIT;
 
 		// With buyout limit and buyouts of previous periods
 		BuyoutLimit::<Test>::put(200 * UNIT);
@@ -375,7 +378,7 @@ fn attempt_buyout_after_buyout_limit_exceeded_fails() {
 	run_test(|| {
 		let user = USER;
 		let dot_currency_id = RelayChainCurrencyId::get();
-		let exchange_amount = 100 * UNIT;
+		let exchange_amount = 1 * UNIT;
 
 		let current_block = frame_system::Pallet::<Test>::block_number().saturated_into::<u32>();
 

--- a/runtime/amplitude/Cargo.toml
+++ b/runtime/amplitude/Cargo.toml
@@ -42,7 +42,7 @@ redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features
 issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
 nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
 replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
 module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
 module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
 module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }

--- a/runtime/amplitude/Cargo.toml
+++ b/runtime/amplitude/Cargo.toml
@@ -30,27 +30,27 @@ token-chain-extension = {path = "../../chain-extensions/token", default-features
 price-chain-extension = {path = "../../chain-extensions/price", default-features = false }
 
 # Custom libraries for Spacewalk
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 module-pallet-staking-rpc-runtime-api = { path = "../../pallets/parachain-staking/rpc/runtime-api", default-features = false }
-pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 
 
 # Substrate

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1489,7 +1489,10 @@ impl spacewalk_primitives::DecimalsLookup for DecimalsLookupImpl {
 
 	fn decimals(currency_id: Self::CurrencyId) -> u32 {
 		// Returning 0 in case no decimals are found
-		AssetRegistry::metadata(currency_id).unwrap_or_else(0).decimals
+		match AssetRegistry::metadata(currency_id) {
+			Some(metadata) => metadata.decimals,
+			None => 0,
+		}
 	}
 }
 

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1238,7 +1238,7 @@ impl<K, V, A> orml_traits::DataProvider<K, V> for DataFeederBenchmark<K, V, A> {
 impl oracle::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = oracle::SubstrateWeight<Runtime>;
-	type DecimalsLookup = spacewalk_primitives::AmplitudeDecimalsLookup;
+	type DecimalsLookup = DecimalsLookupImpl;
 	type DataProvider = DataProviderImpl;
 	#[cfg(feature = "runtime-benchmarks")]
 	type DataFeeder = MockDataFeeder<Self::AccountId, Moment>;
@@ -1488,10 +1488,10 @@ impl spacewalk_primitives::DecimalsLookup for DecimalsLookupImpl {
 	type CurrencyId = CurrencyId;
 
 	fn decimals(currency_id: Self::CurrencyId) -> u32 {
-		// Returning 0 in case no decimals are found
+		// Fallback to hard-coded implementation in case no decimals are found in asset registry
 		match AssetRegistry::metadata(currency_id) {
 			Some(metadata) => metadata.decimals,
-			None => 0,
+			None => spacewalk_primitives::AmplitudeDecimalsLookup::decimals(currency_id),
 		}
 	}
 }

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1483,6 +1483,16 @@ impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
 	}
 }
 
+pub struct DecimalsLookupImpl;
+impl spacewalk_primitives::DecimalsLookup for DecimalsLookupImpl {
+	type CurrencyId = CurrencyId;
+
+	fn decimals(currency_id: Self::CurrencyId) -> u32 {
+		// Returning 0 in case no decimals are found
+		AssetRegistry::metadata(currency_id).unwrap_or_else(0).decimals
+	}
+}
+
 parameter_types! {
 	pub const SellFee: Permill = Permill::from_percent(5);
 	pub const MinAmountToBuyout: Balance = 100 * MILLIUNIT; // 0.1 AMPE or 100_000_000_000
@@ -1499,6 +1509,7 @@ impl treasury_buyout_extension::Config for Runtime {
 	type BuyoutPeriod = BuyoutPeriod;
 	type SellFee = SellFee;
 	type PriceGetter = OraclePriceGetter;
+	type DecimalsLookup = DecimalsLookupImpl;
 	type MinAmountToBuyout = MinAmountToBuyout;
 	type MaxAllowedBuyoutCurrencies = MaxAllowedBuyoutCurrencies;
 	type WeightInfo = treasury_buyout_extension::default_weights::SubstrateWeight<Runtime>;

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -34,7 +34,7 @@ orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-modu
 dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.42" }
 zenlink-protocol = { git = "https://github.com/zenlinkpro/Zenlink-DEX-Module", default-features = false, branch = "polkadot-v0.9.42" }
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
 
 [features]
 default = [

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -34,7 +34,7 @@ orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-modu
 dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.42" }
 zenlink-protocol = { git = "https://github.com/zenlinkpro/Zenlink-DEX-Module", default-features = false, branch = "polkadot-v0.9.42" }
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 
 [features]
 default = [

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -42,7 +42,7 @@ redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features
 issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
 nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
 replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
 pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
 reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
 

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -30,27 +30,27 @@ token-chain-extension = {path = "../../chain-extensions/token", default-features
 price-chain-extension = {path = "../../chain-extensions/price", default-features = false }
 
 # custom libraries from spacewalk
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
-pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 module-pallet-staking-rpc-runtime-api = { path = "../../pallets/parachain-staking/rpc/runtime-api", default-features = false }
 
 # Substrate

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1095,10 +1095,10 @@ impl spacewalk_primitives::DecimalsLookup for DecimalsLookupImpl {
 	type CurrencyId = CurrencyId;
 
 	fn decimals(currency_id: Self::CurrencyId) -> u32 {
-		// Returning 0 in case no decimals are found
+		// Fallback to hard-coded implementation in case no decimals are found in asset registry
 		match AssetRegistry::metadata(currency_id) {
 			Some(metadata) => metadata.decimals,
-			None => 0,
+			None => spacewalk_primitives::AmplitudeDecimalsLookup::decimals(currency_id),
 		}
 	}
 }
@@ -1323,7 +1323,7 @@ impl staking::Config for Runtime {
 impl oracle::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = oracle::SubstrateWeight<Runtime>;
-	type DecimalsLookup = spacewalk_primitives::AmplitudeDecimalsLookup;
+	type DecimalsLookup = DecimalsLookupImpl;
 	type DataProvider = DataProviderImpl;
 	#[cfg(feature = "runtime-benchmarks")]
 	type DataFeeder = MockDataFeeder<Self::AccountId, Moment>;

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1090,6 +1090,16 @@ impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
 	}
 }
 
+pub struct DecimalsLookupImpl;
+impl spacewalk_primitives::DecimalsLookup for DecimalsLookupImpl {
+	type CurrencyId = CurrencyId;
+
+	fn decimals(currency_id: Self::CurrencyId) -> u32 {
+		// Returning 0 in case no decimals are found
+		AssetRegistry::metadata(currency_id).unwrap_or_else(0).decimals
+	}
+}
+
 parameter_types! {
 	pub const SellFee: Permill = Permill::from_percent(1);
 	pub const MinAmountToBuyout: Balance = NANOUNIT;
@@ -1106,6 +1116,7 @@ impl treasury_buyout_extension::Config for Runtime {
 	type BuyoutPeriod = BuyoutPeriod;
 	type SellFee = SellFee;
 	type PriceGetter = OraclePriceGetter;
+	type DecimalsLookup = DecimalsLookupImpl;
 	type MinAmountToBuyout = MinAmountToBuyout;
 	type MaxAllowedBuyoutCurrencies = MaxAllowedBuyoutCurrencies;
 	type WeightInfo = treasury_buyout_extension::default_weights::SubstrateWeight<Runtime>;

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1096,7 +1096,10 @@ impl spacewalk_primitives::DecimalsLookup for DecimalsLookupImpl {
 
 	fn decimals(currency_id: Self::CurrencyId) -> u32 {
 		// Returning 0 in case no decimals are found
-		AssetRegistry::metadata(currency_id).unwrap_or_else(0).decimals
+		match AssetRegistry::metadata(currency_id) {
+			Some(metadata) => metadata.decimals,
+			None => 0,
+		}
 	}
 }
 

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0.144", features = ["derive"] }
 paste = "1.0.14"
 
 # Spacewalk libraries
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
 
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0.144", features = ["derive"] }
 paste = "1.0.14"
 
 # Spacewalk libraries
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }

--- a/runtime/pendulum/Cargo.toml
+++ b/runtime/pendulum/Cargo.toml
@@ -30,27 +30,27 @@ price-chain-extension = {path = "../../chain-extensions/price", default-features
 treasury-buyout-extension = {path = "../../pallets/treasury-buyout-extension", default-features = false}
 
 # Custom libraries for Spacewalk
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 module-pallet-staking-rpc-runtime-api = { path = "../../pallets/parachain-staking/rpc/runtime-api", default-features = false }
-pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.42" }

--- a/runtime/pendulum/Cargo.toml
+++ b/runtime/pendulum/Cargo.toml
@@ -42,7 +42,7 @@ redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features
 issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
 nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
 replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, branch ="522-modify-decimalslookup-trait-to-use-its-own-currencyid-type"}
 module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
 module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }
 module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "3c03e759a6f600ea72d636d4f9cc4b05d633201c" }

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -1229,7 +1229,7 @@ impl<K, V, A> orml_traits::DataProvider<K, V> for DataFeederBenchmark<K, V, A> {
 impl oracle::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = oracle::SubstrateWeight<Runtime>;
-	type DecimalsLookup = spacewalk_primitives::PendulumDecimalsLookup;
+	type DecimalsLookup = DecimalsLookupImpl;
 	type DataProvider = DataProviderImpl;
 	#[cfg(feature = "runtime-benchmarks")]
 	type DataFeeder = MockDataFeeder<Self::AccountId, Moment>;
@@ -1456,10 +1456,10 @@ impl spacewalk_primitives::DecimalsLookup for DecimalsLookupImpl {
 	type CurrencyId = CurrencyId;
 
 	fn decimals(currency_id: Self::CurrencyId) -> u32 {
-		// Returning 0 in case no decimals are found
+		// Fallback to hard-coded implementation in case no decimals are found in asset registry
 		match AssetRegistry::metadata(currency_id) {
 			Some(metadata) => metadata.decimals,
-			None => 0,
+			None => spacewalk_primitives::PendulumDecimalsLookup::decimals(currency_id),
 		}
 	}
 }

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -1457,7 +1457,10 @@ impl spacewalk_primitives::DecimalsLookup for DecimalsLookupImpl {
 
 	fn decimals(currency_id: Self::CurrencyId) -> u32 {
 		// Returning 0 in case no decimals are found
-		AssetRegistry::metadata(currency_id).unwrap_or_else(0).decimals
+		match AssetRegistry::metadata(currency_id) {
+			Some(metadata) => metadata.decimals,
+			None => 0,
+		}
 	}
 }
 

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -1451,6 +1451,16 @@ impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
 	}
 }
 
+pub struct DecimalsLookupImpl;
+impl spacewalk_primitives::DecimalsLookup for DecimalsLookupImpl {
+	type CurrencyId = CurrencyId;
+
+	fn decimals(currency_id: Self::CurrencyId) -> u32 {
+		// Returning 0 in case no decimals are found
+		AssetRegistry::metadata(currency_id).unwrap_or_else(0).decimals
+	}
+}
+
 parameter_types! {
 	pub const SellFee: Permill = Permill::from_percent(5);
 	pub const MinAmountToBuyout: Balance = 100 * MILLIUNIT; // 0.1 PEN or 100_000_000_000
@@ -1467,6 +1477,7 @@ impl treasury_buyout_extension::Config for Runtime {
 	type BuyoutPeriod = BuyoutPeriod;
 	type SellFee = SellFee;
 	type PriceGetter = OraclePriceGetter;
+	type DecimalsLookup = DecimalsLookupImpl;
 	type MinAmountToBuyout = MinAmountToBuyout;
 	type MaxAllowedBuyoutCurrencies = MaxAllowedBuyoutCurrencies;
 	type WeightInfo = treasury_buyout_extension::default_weights::SubstrateWeight<Runtime>;


### PR DESCRIPTION
Closes #460.

Spacewalk dependencies were updated because [these](https://github.com/pendulum-chain/spacewalk/pull/523) changes were needed.