### PR TITLE
Replace oracle key convertor

### DIFF
--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -7,10 +7,10 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 mod chain_ext;
+pub mod definitions;
 mod weights;
 pub mod xcm_config;
 pub mod zenlink;
-pub mod definitions;
 
 use crate::zenlink::*;
 use bifrost_farming as farming;
@@ -85,11 +85,8 @@ pub use sp_runtime::BuildStorage;
 pub use dia_oracle::dia::AssetId;
 pub use issue::{Event as IssueEvent, IssueRequest};
 pub use nomination::Event as NominationEvent;
-use oracle::{
-	dia,
-	dia::{DiaOracleAdapter, NativeCurrencyKey, XCMCurrencyConversion},
-	OracleKey,
-};
+use oracle::dia::DiaOracleAdapter;
+use oracle::OracleKey;
 pub use redeem::{Event as RedeemEvent, RedeemRequest};
 pub use replace::{Event as ReplaceEvent, ReplaceRequest};
 pub use security::StatusCode;
@@ -224,34 +221,6 @@ pub type Executive = frame_executive::Executive<
 	),
 >;
 
-pub struct AmplitudeDiaOracleKeyConverter;
-
-impl NativeCurrencyKey for AmplitudeDiaOracleKeyConverter {
-	fn native_symbol() -> Vec<u8> {
-		b"AMPE".to_vec()
-	}
-
-	fn native_chain() -> Vec<u8> {
-		b"Amplitude".to_vec()
-	}
-}
-
-impl XCMCurrencyConversion for AmplitudeDiaOracleKeyConverter {
-	fn convert_to_dia_currency_id(token_symbol: u8) -> Option<(Vec<u8>, Vec<u8>)> {
-		match token_symbol {
-			0 => Some((b"Kusama".to_vec(), b"KSM".to_vec())),
-			_ => None,
-		}
-	}
-
-	fn convert_from_dia_currency_id(blockchain: Vec<u8>, symbol: Vec<u8>) -> Option<u8> {
-		match (blockchain.as_slice(), symbol.as_slice()) {
-			(b"Kusama", b"KSM") => Some(0),
-			_ => None,
-		}
-	}
-}
-
 cfg_if::cfg_if! {
 	if #[cfg(feature = "runtime-benchmarks")] {
 		use oracle::testing_utils::{
@@ -270,7 +239,7 @@ cfg_if::cfg_if! {
 			DiaOracleModule,
 			UnsignedFixedPoint,
 			Moment,
-			dia::DiaOracleKeyConvertor<AmplitudeDiaOracleKeyConverter>,
+			asset_registry::AssetRegistryToDiaOracleKeyConvertor<Runtime>,
 			ConvertPrice,
 			ConvertMoment,
 		>;
@@ -413,51 +382,51 @@ impl Contains<RuntimeCall> for BaseFilter {
 	fn contains(call: &RuntimeCall) -> bool {
 		match call {
 			// These modules are all allowed to be called by transactions:
-			RuntimeCall::Bounties(_) |
-			RuntimeCall::ChildBounties(_) |
-			RuntimeCall::ClientsInfo(_) |
-			RuntimeCall::Treasury(_) |
-			RuntimeCall::Tokens(_) |
-			RuntimeCall::Currencies(_) |
-			RuntimeCall::ParachainStaking(_) |
-			RuntimeCall::Democracy(_) |
-			RuntimeCall::Council(_) |
-			RuntimeCall::TechnicalCommittee(_) |
-			RuntimeCall::System(_) |
-			RuntimeCall::Scheduler(_) |
-			RuntimeCall::Preimage(_) |
-			RuntimeCall::Timestamp(_) |
-			RuntimeCall::Balances(_) |
-			RuntimeCall::Session(_) |
-			RuntimeCall::ParachainSystem(_) |
-			RuntimeCall::XcmpQueue(_) |
-			RuntimeCall::PolkadotXcm(_) |
-			RuntimeCall::DmpQueue(_) |
-			RuntimeCall::Utility(_) |
-			RuntimeCall::Vesting(_) |
-			RuntimeCall::XTokens(_) |
-			RuntimeCall::Multisig(_) |
-			RuntimeCall::Identity(_) |
-			RuntimeCall::Contracts(_) |
-			RuntimeCall::ZenlinkProtocol(_) |
-			RuntimeCall::VestingManager(_) |
-			RuntimeCall::DiaOracleModule(_) |
-			RuntimeCall::Fee(_) |
-			RuntimeCall::Issue(_) |
-			RuntimeCall::Nomination(_) |
-			RuntimeCall::Oracle(_) |
-			RuntimeCall::Redeem(_) |
-			RuntimeCall::Replace(_) |
-			RuntimeCall::Security(_) |
-			RuntimeCall::StellarRelay(_) |
-			RuntimeCall::VaultRegistry(_) |
-			RuntimeCall::PooledVaultRewards(_) |
-			RuntimeCall::Farming(_) |
-			RuntimeCall::TokenAllowance(_) |
-			RuntimeCall::AssetRegistry(_) |
-			RuntimeCall::Proxy(_) |
-			RuntimeCall::TreasuryBuyoutExtension(_) |
-			RuntimeCall::RewardDistribution(_) => true,
+			RuntimeCall::Bounties(_)
+			| RuntimeCall::ChildBounties(_)
+			| RuntimeCall::ClientsInfo(_)
+			| RuntimeCall::Treasury(_)
+			| RuntimeCall::Tokens(_)
+			| RuntimeCall::Currencies(_)
+			| RuntimeCall::ParachainStaking(_)
+			| RuntimeCall::Democracy(_)
+			| RuntimeCall::Council(_)
+			| RuntimeCall::TechnicalCommittee(_)
+			| RuntimeCall::System(_)
+			| RuntimeCall::Scheduler(_)
+			| RuntimeCall::Preimage(_)
+			| RuntimeCall::Timestamp(_)
+			| RuntimeCall::Balances(_)
+			| RuntimeCall::Session(_)
+			| RuntimeCall::ParachainSystem(_)
+			| RuntimeCall::XcmpQueue(_)
+			| RuntimeCall::PolkadotXcm(_)
+			| RuntimeCall::DmpQueue(_)
+			| RuntimeCall::Utility(_)
+			| RuntimeCall::Vesting(_)
+			| RuntimeCall::XTokens(_)
+			| RuntimeCall::Multisig(_)
+			| RuntimeCall::Identity(_)
+			| RuntimeCall::Contracts(_)
+			| RuntimeCall::ZenlinkProtocol(_)
+			| RuntimeCall::VestingManager(_)
+			| RuntimeCall::DiaOracleModule(_)
+			| RuntimeCall::Fee(_)
+			| RuntimeCall::Issue(_)
+			| RuntimeCall::Nomination(_)
+			| RuntimeCall::Oracle(_)
+			| RuntimeCall::Redeem(_)
+			| RuntimeCall::Replace(_)
+			| RuntimeCall::Security(_)
+			| RuntimeCall::StellarRelay(_)
+			| RuntimeCall::VaultRegistry(_)
+			| RuntimeCall::PooledVaultRewards(_)
+			| RuntimeCall::Farming(_)
+			| RuntimeCall::TokenAllowance(_)
+			| RuntimeCall::AssetRegistry(_)
+			| RuntimeCall::Proxy(_)
+			| RuntimeCall::TreasuryBuyoutExtension(_)
+			| RuntimeCall::RewardDistribution(_) => true,
 			// All pallets are allowed, but exhaustive match is defensive
 			// in the case of adding new pallets.
 		}

--- a/runtime/common/src/asset_registry.rs
+++ b/runtime/common/src/asset_registry.rs
@@ -108,6 +108,10 @@ impl<
 	> Convert<(Vec<u8>, Vec<u8>), Option<Key>> for AssetRegistryToDiaOracleKeyConvertor<Runtime>
 {
 	fn convert(dia_oracle_key: (Vec<u8>, Vec<u8>)) -> Option<Key> {
+		if dia_oracle_key.0.is_empty() || dia_oracle_key.1.is_empty() {
+			return None;
+		}
+
 		// Try to find the currency id in the asset registry metadata for which the dia keys are
 		// matching the ones provided
 		let blockchain = dia_oracle_key.0;

--- a/runtime/common/src/asset_registry.rs
+++ b/runtime/common/src/asset_registry.rs
@@ -1,15 +1,19 @@
 use crate::*;
 use frame_support::traits::AsEnsureOriginWithArg;
 use frame_system::EnsureRoot;
-use orml_traits::{FixedConversionRateProvider as FixedConversionRateProviderTrait,
-	asset_registry::{AssetMetadata, AssetProcessor, Inspect}};
+use orml_traits::{
+	asset_registry::{AssetMetadata, AssetProcessor, Inspect},
+	FixedConversionRateProvider as FixedConversionRateProviderTrait,
+};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::Get;
-use sp_runtime::{BoundedVec, DispatchError, traits::PhantomData};
+use sp_runtime::{traits::PhantomData, BoundedVec, DispatchError};
 use sp_std::fmt::Debug;
+use sp_std::vec::Vec;
+use spacewalk_primitives::oracle::Key;
 use spacewalk_primitives::CurrencyId;
-use xcm::opaque::v3::{MultiLocation};
+use xcm::opaque::v3::MultiLocation;
 
 #[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Debug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 pub struct StringLimit;
@@ -69,5 +73,51 @@ impl<
 	fn get_fee_per_second(location: &MultiLocation) -> Option<u128> {
 		let metadata = OrmlAssetRegistry::metadata_by_location(&location)?;
 		Some(metadata.additional.fee_per_second)
+	}
+}
+
+// Define a convertor to convert between a CurrencyId and the dia oracle keys using the metadata
+// stored in the asset registry
+pub struct AssetRegistryToDiaOracleKeyConvertor<Runtime>(PhantomData<Runtime>);
+
+impl<
+		Runtime: orml_asset_registry::Config<AssetId = CurrencyId, CustomMetadata = CustomMetadata>,
+	> Convert<Key, Option<(Vec<u8>, Vec<u8>)>> for AssetRegistryToDiaOracleKeyConvertor<Runtime>
+{
+	fn convert(spacewalk_oracle_key: Key) -> Option<(Vec<u8>, Vec<u8>)> {
+		let currency_id = match spacewalk_oracle_key {
+			Key::ExchangeRate(currency_id) => currency_id,
+		};
+
+		// Try to find the dia keys in the asset registry metadata
+		orml_asset_registry::Pallet::<Runtime>::metadata(currency_id).and_then(|metadata| {
+			let dia_keys = metadata.additional.dia_keys;
+			if dia_keys.blockchain.is_empty() || dia_keys.symbol.is_empty() {
+				return None;
+			}
+			return Some((dia_keys.blockchain, dia_keys.symbol));
+		});
+
+		// We didn't find the dia keys in the asset registry metadata
+		None
+	}
+}
+
+impl<
+		Runtime: orml_asset_registry::Config<AssetId = CurrencyId, CustomMetadata = CustomMetadata>,
+	> Convert<(Vec<u8>, Vec<u8>), Option<Key>> for AssetRegistryToDiaOracleKeyConvertor<Runtime>
+{
+	fn convert(dia_oracle_key: (Vec<u8>, Vec<u8>)) -> Option<Key> {
+		// Try to find the currency id in the asset registry metadata for which the dia keys are
+		// matching the ones provided
+		let blockchain = dia_oracle_key.0;
+		let symbol = dia_oracle_key.1;
+		orml_asset_registry::Metadata::<Runtime>::iter().find_map(|(currency_id, metadata)| {
+			let dia_keys = metadata.additional.dia_keys;
+			if dia_keys.blockchain == blockchain && dia_keys.symbol == symbol {
+				return Some(Key::ExchangeRate(currency_id));
+			}
+			None
+		})
 	}
 }

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -223,8 +223,11 @@ impl Convert<(Vec<u8>, Vec<u8>), Option<Key>> for AssetRegistryToDiaOracleKeyCon
 	fn convert(dia_oracle_key: (Vec<u8>, Vec<u8>)) -> Option<Key> {
 		// Try to find the currency id in the asset registry metadata for which the dia keys are
 		// matching the ones provided
-		AssetRegistry::Metadata::iter().find_map(|(currency_id, metadata)| {
-			if metadata.additional.dia_keys == dia_oracle_key {
+		let blockchain = dia_oracle_key.0;
+		let symbol = dia_oracle_key.1;
+		orml_asset_registry::Metadata::<Runtime>::iter().find_map(|(currency_id, metadata)| {
+			let dia_keys = metadata.additional.dia_keys;
+			if dia_keys.blockchain == blockchain && dia_keys.symbol == symbol {
 				return Some(Key::ExchangeRate(currency_id));
 			}
 			None

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1237,8 +1237,6 @@ impl currency::CurrencyConversion<currency::Amount<Runtime>, CurrencyId> for Cur
 
 parameter_types! {
 	pub const RelayChainCurrencyId: CurrencyId = XCM(0);
-	// We just use an arbitrary currency here. Only relevant for benchmarks
-	pub const WrappedCurrencyId: CurrencyId = CurrencyId::StellarNative;
 }
 impl currency::Config for Runtime {
 	type UnsignedFixedPoint = UnsignedFixedPoint;
@@ -1246,8 +1244,6 @@ impl currency::Config for Runtime {
 	type SignedFixedPoint = SignedFixedPoint;
 	type Balance = Balance;
 	type GetRelayChainCurrencyId = RelayChainCurrencyId;
-	#[cfg(feature = "runtime-benchmarks")]
-	type GetWrappedCurrencyId = WrappedCurrencyId;
 	type AssetConversion = primitives::AssetConversion;
 	type BalanceConversion = primitives::BalanceConversion;
 	type CurrencyConversion = CurrencyConvert;

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -7,10 +7,10 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 mod chain_ext;
+pub mod definitions;
 mod weights;
 pub mod xcm_config;
 pub mod zenlink;
-pub mod definitions;
 
 use crate::zenlink::*;
 use xcm::v3::MultiLocation;
@@ -27,11 +27,11 @@ use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{
 		AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, Convert, ConvertInto,
-		Zero, One,
+		One, Zero,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, DispatchError, FixedPointNumber, MultiAddress, Perbill, Permill,
-	Perquintill, SaturatedConversion, FixedU128, 
+	ApplyExtrinsicResult, DispatchError, FixedPointNumber, FixedU128, MultiAddress, Perbill,
+	Permill, Perquintill, SaturatedConversion,
 };
 
 use bifrost_farming as farming;
@@ -43,11 +43,10 @@ use spacewalk_primitives::{
 	UnsignedInner,
 };
 
-
 #[cfg(any(feature = "runtime-benchmarks", feature = "testing-utils"))]
 use oracle::testing_utils::MockDataFeeder;
 
-use sp_std::{marker::PhantomData, prelude::*, fmt::Debug};
+use sp_std::{fmt::Debug, marker::PhantomData, prelude::*};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
@@ -82,11 +81,7 @@ use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 use dia_oracle::DiaOracle;
 pub use issue::{Event as IssueEvent, IssueRequest};
 pub use nomination::Event as NominationEvent;
-use oracle::{
-	dia,
-	dia::{DiaOracleAdapter, NativeCurrencyKey, XCMCurrencyConversion},
-	OracleKey,
-};
+use oracle::{dia::DiaOracleAdapter, OracleKey};
 pub use redeem::{Event as RedeemEvent, RedeemRequest};
 pub use replace::{Event as ReplaceEvent, ReplaceRequest};
 pub use security::StatusCode;
@@ -207,39 +202,11 @@ pub type Executive = frame_executive::Executive<
 	),
 >;
 
-pub struct PendulumDiaOracleKeyConverter;
-
-impl NativeCurrencyKey for PendulumDiaOracleKeyConverter {
-	fn native_symbol() -> Vec<u8> {
-		b"PEN".to_vec()
-	}
-
-	fn native_chain() -> Vec<u8> {
-		b"Pendulum".to_vec()
-	}
-}
-
-impl XCMCurrencyConversion for PendulumDiaOracleKeyConverter {
-	fn convert_to_dia_currency_id(token_symbol: u8) -> Option<(Vec<u8>, Vec<u8>)> {
-		match token_symbol {
-			0 => Some((b"Polkadot".to_vec(), b"DOT".to_vec())),
-			_ => None,
-		}
-	}
-
-	fn convert_from_dia_currency_id(blockchain: Vec<u8>, symbol: Vec<u8>) -> Option<u8> {
-		match (blockchain.as_slice(), symbol.as_slice()) {
-			(b"Polkadot", b"DOT") => Some(0),
-			_ => None,
-		}
-	}
-}
-
 type DataProviderImpl = DiaOracleAdapter<
 	DiaOracleModule,
 	UnsignedFixedPoint,
 	Moment,
-	dia::DiaOracleKeyConvertor<PendulumDiaOracleKeyConverter>,
+	asset_registry::AssetRegistryToDiaOracleKeyConvertor<Runtime>,
 	ConvertPrice,
 	ConvertMoment,
 >;
@@ -380,51 +347,51 @@ impl Contains<RuntimeCall> for BaseFilter {
 	fn contains(call: &RuntimeCall) -> bool {
 		match call {
 			// These modules are all allowed to be called by transactions:
-			RuntimeCall::Bounties(_) |
-			RuntimeCall::ChildBounties(_) |
-			RuntimeCall::ClientsInfo(_) |
-			RuntimeCall::Treasury(_) |
-			RuntimeCall::Tokens(_) |
-			RuntimeCall::Currencies(_) |
-			RuntimeCall::ParachainStaking(_) |
-			RuntimeCall::Democracy(_) |
-			RuntimeCall::Council(_) |
-			RuntimeCall::TechnicalCommittee(_) |
-			RuntimeCall::System(_) |
-			RuntimeCall::Scheduler(_) |
-			RuntimeCall::Preimage(_) |
-			RuntimeCall::Timestamp(_) |
-			RuntimeCall::Balances(_) |
-			RuntimeCall::Session(_) |
-			RuntimeCall::ParachainSystem(_) |
-			RuntimeCall::XcmpQueue(_) |
-			RuntimeCall::PolkadotXcm(_) |
-			RuntimeCall::DmpQueue(_) |
-			RuntimeCall::Utility(_) |
-			RuntimeCall::Vesting(_) |
-			RuntimeCall::XTokens(_) |
-			RuntimeCall::Multisig(_) |
-			RuntimeCall::Identity(_) |
-			RuntimeCall::Contracts(_) |
-			RuntimeCall::ZenlinkProtocol(_) |
-			RuntimeCall::DiaOracleModule(_) |
-			RuntimeCall::VestingManager(_) |
-			RuntimeCall::TokenAllowance(_) |
-			RuntimeCall::AssetRegistry(_) |
-			RuntimeCall::Fee(_) |
-			RuntimeCall::Issue(_) |
-			RuntimeCall::Nomination(_) |
-			RuntimeCall::Oracle(_) |
-			RuntimeCall::Redeem(_) |
-			RuntimeCall::Replace(_) |
-			RuntimeCall::Security(_) |
-			RuntimeCall::StellarRelay(_) |
-			RuntimeCall::VaultRegistry(_) |
-			RuntimeCall::PooledVaultRewards(_) |
-			RuntimeCall::RewardDistribution(_) |
-			RuntimeCall::Farming(_) |
-			RuntimeCall::Proxy(_) |
-			RuntimeCall::TreasuryBuyoutExtension(_) => true,
+			RuntimeCall::Bounties(_)
+			| RuntimeCall::ChildBounties(_)
+			| RuntimeCall::ClientsInfo(_)
+			| RuntimeCall::Treasury(_)
+			| RuntimeCall::Tokens(_)
+			| RuntimeCall::Currencies(_)
+			| RuntimeCall::ParachainStaking(_)
+			| RuntimeCall::Democracy(_)
+			| RuntimeCall::Council(_)
+			| RuntimeCall::TechnicalCommittee(_)
+			| RuntimeCall::System(_)
+			| RuntimeCall::Scheduler(_)
+			| RuntimeCall::Preimage(_)
+			| RuntimeCall::Timestamp(_)
+			| RuntimeCall::Balances(_)
+			| RuntimeCall::Session(_)
+			| RuntimeCall::ParachainSystem(_)
+			| RuntimeCall::XcmpQueue(_)
+			| RuntimeCall::PolkadotXcm(_)
+			| RuntimeCall::DmpQueue(_)
+			| RuntimeCall::Utility(_)
+			| RuntimeCall::Vesting(_)
+			| RuntimeCall::XTokens(_)
+			| RuntimeCall::Multisig(_)
+			| RuntimeCall::Identity(_)
+			| RuntimeCall::Contracts(_)
+			| RuntimeCall::ZenlinkProtocol(_)
+			| RuntimeCall::DiaOracleModule(_)
+			| RuntimeCall::VestingManager(_)
+			| RuntimeCall::TokenAllowance(_)
+			| RuntimeCall::AssetRegistry(_)
+			| RuntimeCall::Fee(_)
+			| RuntimeCall::Issue(_)
+			| RuntimeCall::Nomination(_)
+			| RuntimeCall::Oracle(_)
+			| RuntimeCall::Redeem(_)
+			| RuntimeCall::Replace(_)
+			| RuntimeCall::Security(_)
+			| RuntimeCall::StellarRelay(_)
+			| RuntimeCall::VaultRegistry(_)
+			| RuntimeCall::PooledVaultRewards(_)
+			| RuntimeCall::RewardDistribution(_)
+			| RuntimeCall::Farming(_)
+			| RuntimeCall::Proxy(_)
+			| RuntimeCall::TreasuryBuyoutExtension(_) => true,
 			// All pallets are allowed, but exhaustive match is defensive
 			// in the case of adding new pallets.
 		}


### PR DESCRIPTION
<!-- If you added changes to files in the `node` directory or any other changes that would require a re-deployment of the collator nodes, please add the following line to the PR description:
@pendulum-chain/product: This PR adds changes to the node client code that require a **redeployment of the collator nodes** to take effect. 
Please ensure that the collator nodes are redeployed after this PR is merged.  
-->

Introduces a new struct that converts between `CurrencyId` <> `DiaKeys` using the metadata in the asset registry. The lookup of `DiaKeys -> CurrencyId` can be costly because we are potentially iterating over all elements of the `StorageMap` but since we don't have that many assets in the registry it should be fine.

<!-- Replace xx with the issue number that is fixed by this pull request. -->
Closes #469. 