### PR TITLE
445 replace oraclekey enums used in treasury buyout extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14246,7 +14246,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "mocktopus",
- "orml-asset-registry",
  "orml-currencies",
  "orml-tokens 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library.git?branch=polkadot-v0.9.42)",
  "orml-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10584,6 +10584,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "spacewalk-primitives",
+ "treasury-buyout-extension",
  "xcm",
  "xcm-executor",
  "zenlink-protocol",

--- a/pallets/treasury-buyout-extension/Cargo.toml
+++ b/pallets/treasury-buyout-extension/Cargo.toml
@@ -24,7 +24,6 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch =
 orml-currencies = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.42", default-features = false }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.42", default-features = false }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.42", default-features = false }
-orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.42", default-features = false }
 
 spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
 
@@ -54,7 +53,6 @@ std = [
   "orml-currencies/std",
   "orml-tokens/std",
   "orml-traits/std",
-  "orml-asset-registry/std",
   "frame-benchmarking/std",
   "pallet-balances/std",
   "spacewalk-primitives/std",
@@ -75,6 +73,5 @@ try-runtime = [
     "frame-system/try-runtime",
     "orml-currencies/try-runtime",
     "orml-tokens/try-runtime",
-    "orml-asset-registry/try-runtime",
     "pallet-balances/try-runtime"
 ]

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1430,53 +1430,6 @@ impl orml_currencies_allowance_extension::Config for Runtime {
 	type MaxAllowedCurrencies = ConstU32<256>;
 }
 
-pub struct OraclePriceGetter(DiaOracleModule);
-
-impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
-	#[cfg(not(feature = "runtime-benchmarks"))]
-	fn get_price<FixedNumber>(currency_id: CurrencyId) -> Result<FixedNumber, DispatchError>
-	where
-		FixedNumber: FixedPointNumber + One + Zero + Debug + TryFrom<FixedU128>,
-	{
-		let asset_metadata = AssetRegistry::metadata(currency_id)
-        .ok_or(DispatchError::Other("Asset not found"))?;
-
-		let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
-		let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
-
-		if let Ok(asset_info) = DiaOracleModule::get_coin_info(blockchain, symbol) {
-			let price = FixedNumber::try_from(FixedU128::from_inner(asset_info.price)).map_err(|_| DispatchError::Other("Failed to convert price"))?;
-			return Ok(price);
-		} else {
-			return Err(DispatchError::Other("Failed to get coin info"));
-		}
-	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn get_price<FixedNumber>(currency_id: CurrencyId) -> Result<FixedNumber, DispatchError>
-	where
-		FixedNumber: FixedPointNumber + One + Zero + Debug + TryFrom<FixedU128>,
-	{
-		// Forcefully set chain status to running when benchmarking so that the oracle doesn't fail
-		Security::set_status(StatusCode::Running);
-
-		let asset_metadata = AssetRegistry::metadata(currency_id)
-        .ok_or(DispatchError::Other("Asset not found"))?;
-
-		let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
-		let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
-
-		if let Ok(asset_info) = DiaOracleModule::get_coin_info(blockchain, symbol) {
-			let price = FixedNumber::try_from(FixedU128::from_inner(asset_info.price)).map_err(|_| DispatchError::Other("Failed to convert price"))?;
-			Ok(price)
-		} else {
-			// Returning a default value in case fetching a real price from the oracle fails
-			let price = FixedNumber::checked_from_rational(100, 1).expect("This is a valid ratio");
-			Ok(price)
-		}
-	}
-}
-
 pub struct DecimalsLookupImpl;
 impl spacewalk_primitives::DecimalsLookup for DecimalsLookupImpl {
 	type CurrencyId = CurrencyId;
@@ -1505,7 +1458,7 @@ impl treasury_buyout_extension::Config for Runtime {
 	type TreasuryAccount = AmplitudeTreasuryAccount;
 	type BuyoutPeriod = BuyoutPeriod;
 	type SellFee = SellFee;
-	type PriceGetter = OraclePriceGetter;
+	type PriceGetter = runtime_common::OraclePriceGetter<Runtime>;
 	type DecimalsLookup = DecimalsLookupImpl;
 	type MinAmountToBuyout = MinAmountToBuyout;
 	type MaxAllowedBuyoutCurrencies = MaxAllowedBuyoutCurrencies;

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -7,10 +7,10 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 mod chain_ext;
+pub mod definitions;
 mod weights;
 pub mod xcm_config;
 pub mod zenlink;
-pub mod definitions;
 
 use crate::zenlink::*;
 use bifrost_farming as farming;
@@ -408,51 +408,51 @@ impl Contains<RuntimeCall> for BaseFilter {
 	fn contains(call: &RuntimeCall) -> bool {
 		match call {
 			// These modules are all allowed to be called by transactions:
-			RuntimeCall::Bounties(_) |
-			RuntimeCall::ChildBounties(_) |
-			RuntimeCall::ClientsInfo(_) |
-			RuntimeCall::Treasury(_) |
-			RuntimeCall::Tokens(_) |
-			RuntimeCall::Currencies(_) |
-			RuntimeCall::ParachainStaking(_) |
-			RuntimeCall::Democracy(_) |
-			RuntimeCall::Council(_) |
-			RuntimeCall::TechnicalCommittee(_) |
-			RuntimeCall::System(_) |
-			RuntimeCall::Scheduler(_) |
-			RuntimeCall::Preimage(_) |
-			RuntimeCall::Timestamp(_) |
-			RuntimeCall::Balances(_) |
-			RuntimeCall::Session(_) |
-			RuntimeCall::ParachainSystem(_) |
-			RuntimeCall::XcmpQueue(_) |
-			RuntimeCall::PolkadotXcm(_) |
-			RuntimeCall::DmpQueue(_) |
-			RuntimeCall::Utility(_) |
-			RuntimeCall::Vesting(_) |
-			RuntimeCall::XTokens(_) |
-			RuntimeCall::Multisig(_) |
-			RuntimeCall::Identity(_) |
-			RuntimeCall::Contracts(_) |
-			RuntimeCall::ZenlinkProtocol(_) |
-			RuntimeCall::VestingManager(_) |
-			RuntimeCall::DiaOracleModule(_) |
-			RuntimeCall::Fee(_) |
-			RuntimeCall::Issue(_) |
-			RuntimeCall::Nomination(_) |
-			RuntimeCall::Oracle(_) |
-			RuntimeCall::Redeem(_) |
-			RuntimeCall::Replace(_) |
-			RuntimeCall::Security(_) |
-			RuntimeCall::StellarRelay(_) |
-			RuntimeCall::VaultRegistry(_) |
-			RuntimeCall::PooledVaultRewards(_) |
-			RuntimeCall::Farming(_) |
-			RuntimeCall::TokenAllowance(_) |
-			RuntimeCall::AssetRegistry(_) |
-			RuntimeCall::Proxy(_) |
-			RuntimeCall::TreasuryBuyoutExtension(_) |
-			RuntimeCall::RewardDistribution(_) => true,
+			RuntimeCall::Bounties(_)
+			| RuntimeCall::ChildBounties(_)
+			| RuntimeCall::ClientsInfo(_)
+			| RuntimeCall::Treasury(_)
+			| RuntimeCall::Tokens(_)
+			| RuntimeCall::Currencies(_)
+			| RuntimeCall::ParachainStaking(_)
+			| RuntimeCall::Democracy(_)
+			| RuntimeCall::Council(_)
+			| RuntimeCall::TechnicalCommittee(_)
+			| RuntimeCall::System(_)
+			| RuntimeCall::Scheduler(_)
+			| RuntimeCall::Preimage(_)
+			| RuntimeCall::Timestamp(_)
+			| RuntimeCall::Balances(_)
+			| RuntimeCall::Session(_)
+			| RuntimeCall::ParachainSystem(_)
+			| RuntimeCall::XcmpQueue(_)
+			| RuntimeCall::PolkadotXcm(_)
+			| RuntimeCall::DmpQueue(_)
+			| RuntimeCall::Utility(_)
+			| RuntimeCall::Vesting(_)
+			| RuntimeCall::XTokens(_)
+			| RuntimeCall::Multisig(_)
+			| RuntimeCall::Identity(_)
+			| RuntimeCall::Contracts(_)
+			| RuntimeCall::ZenlinkProtocol(_)
+			| RuntimeCall::VestingManager(_)
+			| RuntimeCall::DiaOracleModule(_)
+			| RuntimeCall::Fee(_)
+			| RuntimeCall::Issue(_)
+			| RuntimeCall::Nomination(_)
+			| RuntimeCall::Oracle(_)
+			| RuntimeCall::Redeem(_)
+			| RuntimeCall::Replace(_)
+			| RuntimeCall::Security(_)
+			| RuntimeCall::StellarRelay(_)
+			| RuntimeCall::VaultRegistry(_)
+			| RuntimeCall::PooledVaultRewards(_)
+			| RuntimeCall::Farming(_)
+			| RuntimeCall::TokenAllowance(_)
+			| RuntimeCall::AssetRegistry(_)
+			| RuntimeCall::Proxy(_)
+			| RuntimeCall::TreasuryBuyoutExtension(_)
+			| RuntimeCall::RewardDistribution(_) => true,
 			// All pallets are allowed, but exhaustive match is defensive
 			// in the case of adding new pallets.
 		}

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -1430,7 +1430,7 @@ impl orml_currencies_allowance_extension::Config for Runtime {
 	type MaxAllowedCurrencies = ConstU32<256>;
 }
 
-pub struct OraclePriceGetter(Oracle);
+pub struct OraclePriceGetter(DiaOracleModule);
 
 impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
 	#[cfg(not(feature = "runtime-benchmarks"))]
@@ -1438,14 +1438,17 @@ impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
 	where
 		FixedNumber: FixedPointNumber + One + Zero + Debug + TryFrom<FixedU128>,
 	{
-		let key = OracleKey::ExchangeRate(currency_id);
-		let asset_price = Oracle::get_price(key.clone())?;
+		let asset_metadata = AssetRegistry::metadata(currency_id)
+        .ok_or(DispatchError::Other("Asset not found"))?;
 
-		let converted_asset_price = FixedNumber::try_from(asset_price);
+		let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
+		let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
 
-		match converted_asset_price {
-			Ok(price) => Ok(price),
-			Err(_) => Err(DispatchError::Other("Failed to convert price")),
+		if let Ok(asset_info) = DiaOracleModule::get_coin_info(blockchain, symbol) {
+			let price = FixedNumber::try_from(FixedU128::from_inner(asset_info.price)).map_err(|_| DispatchError::Other("Failed to convert price"))?;
+			return Ok(price);
+		} else {
+			return Err(DispatchError::Other("Failed to get coin info"));
 		}
 	}
 
@@ -1457,28 +1460,19 @@ impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
 		// Forcefully set chain status to running when benchmarking so that the oracle doesn't fail
 		Security::set_status(StatusCode::Running);
 
-		let key = OracleKey::ExchangeRate(currency_id);
+		let asset_metadata = AssetRegistry::metadata(currency_id)
+        .ok_or(DispatchError::Other("Asset not found"))?;
 
-		// Attempt to get the price once and use the result to decide if feeding a value is necessary
-		match Oracle::get_price(key.clone()) {
-			Ok(asset_price) => {
-				// If the price is successfully retrieved, use it directly
-				let converted_asset_price = FixedNumber::try_from(asset_price)
-					.map_err(|_| DispatchError::Other("Failed to convert price"))?;
-				Ok(converted_asset_price)
-			},
-			Err(_) => {
-				// Price not found, feed the default value
-				let rate = FixedU128::checked_from_rational(100, 1).expect("This is a valid ratio");
-				// Account used for feeding values
-				let account = AccountId::from([0u8; 32]);
-				Oracle::feed_values(account, vec![(key.clone(), rate)])?;
+		let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
+		let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
 
-				// If feeding was successful, just use the feeded price to spare a read
-				let converted_asset_price = FixedNumber::try_from(rate)
-					.map_err(|_| DispatchError::Other("Failed to convert price"))?;
-				Ok(converted_asset_price)
-			},
+		if let Ok(asset_info) = DiaOracleModule::get_coin_info(blockchain, symbol) {
+			let price = FixedNumber::try_from(FixedU128::from_inner(asset_info.price)).map_err(|_| DispatchError::Other("Failed to convert price"))?;
+			Ok(price)
+		} else {
+			// Returning a default value in case fetching a real price from the oracle fails
+			let price = FixedNumber::checked_from_rational(100, 1).expect("This is a valid ratio");
+			Ok(price)
 		}
 	}
 }

--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -29,10 +29,9 @@ use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{
 		AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, Convert, ConvertInto,
-		One, Zero,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, DispatchError, FixedPointNumber, FixedU128, SaturatedConversion,
+	ApplyExtrinsicResult, DispatchError, FixedPointNumber, SaturatedConversion,
 };
 
 const CONTRACTS_DEBUG_OUTPUT: bool = true;
@@ -85,11 +84,7 @@ pub use sp_runtime::BuildStorage;
 pub use dia_oracle::dia::AssetId;
 pub use issue::{Event as IssueEvent, IssueRequest};
 pub use nomination::Event as NominationEvent;
-use oracle::{
-	dia,
-	dia::{DiaOracleAdapter, NativeCurrencyKey, XCMCurrencyConversion},
-	OracleKey,
-};
+use oracle::dia::{DiaOracleAdapter, NativeCurrencyKey, XCMCurrencyConversion};
 pub use redeem::{Event as RedeemEvent, RedeemRequest};
 pub use replace::{Event as ReplaceEvent, ReplaceRequest};
 pub use security::StatusCode;

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -35,6 +35,7 @@ dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-
 zenlink-protocol = { git = "https://github.com/zenlinkpro/Zenlink-DEX-Module", default-features = false, branch = "polkadot-v0.9.42" }
 
 spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev ="e7a672ba1e21c98a70df30a6ee458317951dd597"}
+treasury-buyout-extension = { path = "../../pallets/treasury-buyout-extension", default-features = false }
 
 [features]
 default = [
@@ -60,6 +61,8 @@ std = [
     "zenlink-protocol/std",
     "spacewalk-primitives/std",
     "cumulus-primitives-core/std",
+    "treasury-buyout-extension/std",
+
 ]
 
 runtime-benchmarks = [
@@ -67,4 +70,6 @@ runtime-benchmarks = [
     "sp-runtime/runtime-benchmarks",
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
+    "treasury-buyout-extension/runtime-benchmarks",
+
 ]

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -256,7 +256,7 @@ impl<
 					..Default::default()
 				},
 			)];
-			// If this fails, we still want to return a default price so we don't throw an error here
+			// If this fails, we still want to return a default price so we don't handle the result here
 			let _ = dia_oracle::Pallet::<Runtime>::set_updated_coin_infos(
 				frame_system::RawOrigin::Root.into(),
 				coin_infos,

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -1,21 +1,18 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(non_snake_case)]
 
+use asset_registry::CustomMetadata;
 use core::{fmt::Debug, marker::PhantomData};
+use dia_oracle::DiaOracle;
+use orml_traits::asset_registry::Inspect;
 use parity_scale_codec::EncodeLike;
 use sp_runtime::{
-	traits::{IdentifyAccount, Verify, Convert, One, Zero},
-	MultiSignature,
-	DispatchError, 
-	FixedPointNumber,
-	FixedU128,
+	traits::{Convert, IdentifyAccount, One, Verify, Zero},
+	DispatchError, FixedPointNumber, FixedU128, MultiSignature,
 };
 use spacewalk_primitives::CurrencyId;
 use treasury_buyout_extension::PriceGetter;
-use dia_oracle::DiaOracle;
-use xcm::v3::{MultiAsset, AssetId, MultiLocation};
-use orml_traits::asset_registry::Inspect;
-use asset_registry::CustomMetadata;
+use xcm::v3::{AssetId, MultiAsset, MultiLocation};
 
 pub mod asset_registry;
 pub mod custom_transactor;
@@ -62,8 +59,6 @@ pub type Index = u32;
 
 /// A hash of some data used by the chain.
 pub type Hash = sp_core::H256;
-
-
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
@@ -157,7 +152,10 @@ pub mod parachains {
 /// in the form of a `MultiLocation`, in this case a pCfg (Para-Id, Currency-Id).
 pub struct CurrencyIdConvert<AssetRegistry>(sp_std::marker::PhantomData<AssetRegistry>);
 
-impl<AssetRegistry: Inspect<AssetId = CurrencyId,Balance = Balance, CustomMetadata = CustomMetadata>> Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert<AssetRegistry> {
+impl<
+		AssetRegistry: Inspect<AssetId = CurrencyId, Balance = Balance, CustomMetadata = CustomMetadata>,
+	> Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert<AssetRegistry>
+{
 	fn convert(id: CurrencyId) -> Option<MultiLocation> {
 		<AssetRegistry as Inspect>::metadata(&id)
 			.filter(|m| m.location.is_some())
@@ -166,13 +164,19 @@ impl<AssetRegistry: Inspect<AssetId = CurrencyId,Balance = Balance, CustomMetada
 	}
 }
 
-impl<AssetRegistry: Inspect<AssetId = CurrencyId,Balance = Balance, CustomMetadata = CustomMetadata>> Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert<AssetRegistry> {
-	fn convert(location: MultiLocation) -> Option<CurrencyId>  {
+impl<
+		AssetRegistry: Inspect<AssetId = CurrencyId, Balance = Balance, CustomMetadata = CustomMetadata>,
+	> Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert<AssetRegistry>
+{
+	fn convert(location: MultiLocation) -> Option<CurrencyId> {
 		<AssetRegistry as Inspect>::asset_id(&location)
 	}
 }
 
-impl<AssetRegistry: Inspect<AssetId = CurrencyId,Balance = Balance, CustomMetadata = CustomMetadata>> Convert<MultiAsset, Option<CurrencyId>> for CurrencyIdConvert<AssetRegistry> {
+impl<
+		AssetRegistry: Inspect<AssetId = CurrencyId, Balance = Balance, CustomMetadata = CustomMetadata>,
+	> Convert<MultiAsset, Option<CurrencyId>> for CurrencyIdConvert<AssetRegistry>
+{
 	fn convert(a: MultiAsset) -> Option<CurrencyId> {
 		if let MultiAsset { id: AssetId::Concrete(id), fun: _ } = a {
 			<Self as Convert<MultiLocation, Option<CurrencyId>>>::convert(id)
@@ -185,16 +189,24 @@ impl<AssetRegistry: Inspect<AssetId = CurrencyId,Balance = Balance, CustomMetada
 /// Convert an incoming `MultiLocation` into a `CurrencyId` if possible.
 /// Here we need to know the canonical representation of all the tokens we handle in order to
 /// correctly convert their `MultiLocation` representation into our internal `CurrencyId` type.
-impl<AssetRegistry: Inspect<AssetId = CurrencyId,Balance = Balance, CustomMetadata = CustomMetadata>> xcm_executor::traits::Convert<MultiLocation, CurrencyId> for CurrencyIdConvert<AssetRegistry> {
+impl<
+		AssetRegistry: Inspect<AssetId = CurrencyId, Balance = Balance, CustomMetadata = CustomMetadata>,
+	> xcm_executor::traits::Convert<MultiLocation, CurrencyId> for CurrencyIdConvert<AssetRegistry>
+{
 	fn convert(location: MultiLocation) -> Result<CurrencyId, MultiLocation> {
-		<CurrencyIdConvert<AssetRegistry> as Convert<MultiLocation, Option<CurrencyId>>>::convert(location)
-			.ok_or(location)
+		<CurrencyIdConvert<AssetRegistry> as Convert<MultiLocation, Option<CurrencyId>>>::convert(
+			location,
+		)
+		.ok_or(location)
 	}
 }
 
-
 pub struct OraclePriceGetter<Runtime>(PhantomData<Runtime>);
-impl < Runtime: treasury_buyout_extension::Config + dia_oracle::Config + orml_asset_registry::Config<AssetId = CurrencyId, CustomMetadata = CustomMetadata> > PriceGetter<CurrencyId> for OraclePriceGetter<Runtime> 
+impl<
+		Runtime: treasury_buyout_extension::Config
+			+ dia_oracle::Config
+			+ orml_asset_registry::Config<AssetId = CurrencyId, CustomMetadata = CustomMetadata>,
+	> PriceGetter<CurrencyId> for OraclePriceGetter<Runtime>
 {
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	fn get_price<FixedNumber>(currency_id: CurrencyId) -> Result<FixedNumber, DispatchError>
@@ -202,13 +214,16 @@ impl < Runtime: treasury_buyout_extension::Config + dia_oracle::Config + orml_as
 		FixedNumber: FixedPointNumber + One + Zero + Debug + TryFrom<FixedU128>,
 	{
 		let asset_metadata = orml_asset_registry::Pallet::<Runtime>::metadata(currency_id)
-        .ok_or(DispatchError::Other("Asset not found"))?;
+			.ok_or(DispatchError::Other("Asset not found"))?;
 
 		let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
 		let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
 
-		if let Ok(asset_info) = <dia_oracle::Pallet<Runtime> as DiaOracle>::get_coin_info(blockchain, symbol) {
-			let price = FixedNumber::try_from(FixedU128::from_inner(asset_info.price)).map_err(|_| DispatchError::Other("Failed to convert price"))?;
+		if let Ok(asset_info) =
+			<dia_oracle::Pallet<Runtime> as DiaOracle>::get_coin_info(blockchain, symbol)
+		{
+			let price = FixedNumber::try_from(FixedU128::from_inner(asset_info.price))
+				.map_err(|_| DispatchError::Other("Failed to convert price"))?;
 			return Ok(price);
 		} else {
 			return Err(DispatchError::Other("Failed to get coin info"));
@@ -223,13 +238,16 @@ impl < Runtime: treasury_buyout_extension::Config + dia_oracle::Config + orml_as
 		Security::set_status(StatusCode::Running);
 
 		let asset_metadata = orml_asset_registry::Pallet::<Runtime>::metadata(currency_id)
-        .ok_or(DispatchError::Other("Asset not found"))?;
+			.ok_or(DispatchError::Other("Asset not found"))?;
 
 		let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
 		let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
 
-		if let Ok(asset_info) = <dia_oracle::Pallet<Runtime> as DiaOracle>::get_coin_info(blockchain, symbol) {
-			let price = FixedNumber::try_from(FixedU128::from_inner(asset_info.price)).map_err(|_| DispatchError::Other("Failed to convert price"))?;
+		if let Ok(asset_info) =
+			<dia_oracle::Pallet<Runtime> as DiaOracle>::get_coin_info(blockchain, symbol)
+		{
+			let price = FixedNumber::try_from(FixedU128::from_inner(asset_info.price))
+				.map_err(|_| DispatchError::Other("Failed to convert price"))?;
 			Ok(price)
 		} else {
 			// Returning a default value in case fetching a real price from the oracle fails

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -234,37 +234,39 @@ impl<
 	where
 		FixedNumber: FixedPointNumber + One + Zero + Debug + TryFrom<FixedU128>,
 	{
-		let default_price = FixedU128::checked_from_rational(100, 1).expect("This is a valid ratio");
+		let default_price =
+			FixedU128::checked_from_rational(100, 1).expect("This is a valid ratio");
 
-		let (blockchain, symbol) = match orml_asset_registry::Pallet::<Runtime>::metadata(currency_id) {
-			Some(asset_metadata) => {
-				let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
-				let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
-				(blockchain, symbol)
-			} ,
-			None => {
-				// If there's no metadata in asset registry, then there's no way to fetch the price
-				// We have to set the price manually in the oracle using the default values for blockchain and symbol
-				let blockchain = b"blockchain".to_vec();
-				let symbol = b"symbol".to_vec();
-				let coin_infos = vec![(
-					(blockchain.clone(), symbol.clone()),
-					CoinInfo {
-						blockchain: blockchain.clone(),
-						symbol: symbol.clone(),
-						price: default_price.into_inner(),
-						..Default::default()
-					},
-				)];
-				// If this fails, we still want to return a default price so we don't throw an error here
-				let _ = dia_oracle::Pallet::<Runtime>::set_updated_coin_infos(
-					frame_system::RawOrigin::Root.into(),
-					coin_infos,
-				);
+		let (blockchain, symbol) =
+			match orml_asset_registry::Pallet::<Runtime>::metadata(currency_id) {
+				Some(asset_metadata) => {
+					let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
+					let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
+					(blockchain, symbol)
+				},
+				None => {
+					// If there's no metadata in asset registry, then there's no way to fetch the price
+					// We have to set the price manually in the oracle using the default values for blockchain and symbol
+					let blockchain = b"blockchain".to_vec();
+					let symbol = b"symbol".to_vec();
+					let coin_infos = vec![(
+						(blockchain.clone(), symbol.clone()),
+						CoinInfo {
+							blockchain: blockchain.clone(),
+							symbol: symbol.clone(),
+							price: default_price.into_inner(),
+							..Default::default()
+						},
+					)];
+					// If this fails, we still want to return a default price so we don't throw an error here
+					let _ = dia_oracle::Pallet::<Runtime>::set_updated_coin_infos(
+						frame_system::RawOrigin::Root.into(),
+						coin_infos,
+					);
 
-				(blockchain, symbol)
-			}
-		};
+					(blockchain, symbol)
+				},
+			};
 
 		if let Ok(asset_info) =
 			<dia_oracle::Pallet<Runtime> as DiaOracle>::get_coin_info(blockchain, symbol)

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -234,34 +234,37 @@ impl<
 	where
 		FixedNumber: FixedPointNumber + One + Zero + Debug + TryFrom<FixedU128>,
 	{
-		// Default values
-		let mut blockchain = b"Blockchain".to_vec();
-		let mut symbol = b"Symbol".to_vec();
-		let default_price =
-			FixedU128::checked_from_rational(100, 1).expect("This is a valid ratio");
+		let default_price = FixedU128::checked_from_rational(100, 1).expect("This is a valid ratio");
 
-		if let Some(asset_metadata) = orml_asset_registry::Pallet::<Runtime>::metadata(currency_id)
-		{
-			blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
-			symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
-		} else {
-			// If there's no metadata in asset registry, then there's no way to fetch the price
-			// We have to set the price manually in the oracle using the default values for blockchain and symbol
-			let coin_infos = vec![(
-				(blockchain.clone(), symbol.clone()),
-				CoinInfo {
-					blockchain: blockchain.clone(),
-					symbol: symbol.clone(),
-					price: default_price.into_inner(),
-					..Default::default()
-				},
-			)];
-			// If this fails, we still want to return a default price so we don't handle the result here
-			let _ = dia_oracle::Pallet::<Runtime>::set_updated_coin_infos(
-				frame_system::RawOrigin::Root.into(),
-				coin_infos,
-			);
-		}
+		let (blockchain, symbol) = match orml_asset_registry::Pallet::<Runtime>::metadata(currency_id) {
+			Some(asset_metadata) => {
+				let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
+				let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
+				(blockchain, symbol)
+			} ,
+			None => {
+				// If there's no metadata in asset registry, then there's no way to fetch the price
+				// We have to set the price manually in the oracle using the default values for blockchain and symbol
+				let blockchain = b"blockchain".to_vec();
+				let symbol = b"symbol".to_vec();
+				let coin_infos = vec![(
+					(blockchain.clone(), symbol.clone()),
+					CoinInfo {
+						blockchain: blockchain.clone(),
+						symbol: symbol.clone(),
+						price: default_price.into_inner(),
+						..Default::default()
+					},
+				)];
+				// If this fails, we still want to return a default price so we don't throw an error here
+				let _ = dia_oracle::Pallet::<Runtime>::set_updated_coin_infos(
+					frame_system::RawOrigin::Root.into(),
+					coin_infos,
+				);
+
+				(blockchain, symbol)
+			}
+		};
 
 		if let Ok(asset_info) =
 			<dia_oracle::Pallet<Runtime> as DiaOracle>::get_coin_info(blockchain, symbol)

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -25,15 +25,14 @@ use codec::Encode;
 
 use smallvec::smallvec;
 use sp_api::impl_runtime_apis;
-use sp_core::{crypto::KeyTypeId, Get, OpaqueMetadata, H256};
+use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H256};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{
 		AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, Convert, ConvertInto,
-		One, Zero,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, DispatchError, FixedPointNumber, FixedU128, SaturatedConversion,
+	ApplyExtrinsicResult, DispatchError, FixedPointNumber, SaturatedConversion,
 };
 use sp_std::fmt::Debug;
 
@@ -69,8 +68,6 @@ use runtime_common::{
 
 #[cfg(any(feature = "runtime-benchmarks", feature = "testing-utils"))]
 use oracle::testing_utils::MockDataFeeder;
-
-use oracle::OracleKey;
 
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -7,10 +7,10 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 mod chain_ext;
+pub mod definitions;
 mod weights;
 pub mod xcm_config;
 pub mod zenlink;
-pub mod definitions;
 
 use crate::zenlink::*;
 use xcm::v3::MultiLocation;
@@ -382,53 +382,53 @@ impl Contains<RuntimeCall> for BaseFilter {
 	fn contains(call: &RuntimeCall) -> bool {
 		match call {
 			// These modules are all allowed to be called by transactions:
-			RuntimeCall::Bounties(_) |
-			RuntimeCall::ChildBounties(_) |
-			RuntimeCall::ClientsInfo(_) |
-			RuntimeCall::Treasury(_) |
-			RuntimeCall::Tokens(_) |
-			RuntimeCall::Currencies(_) |
-			RuntimeCall::ParachainStaking(_) |
-			RuntimeCall::Democracy(_) |
-			RuntimeCall::Council(_) |
-			RuntimeCall::TechnicalCommittee(_) |
-			RuntimeCall::System(_) |
-			RuntimeCall::Scheduler(_) |
-			RuntimeCall::Preimage(_) |
-			RuntimeCall::Timestamp(_) |
-			RuntimeCall::Balances(_) |
-			RuntimeCall::Session(_) |
-			RuntimeCall::ParachainSystem(_) |
-			RuntimeCall::Sudo(_) |
-			RuntimeCall::XcmpQueue(_) |
-			RuntimeCall::PolkadotXcm(_) |
-			RuntimeCall::DmpQueue(_) |
-			RuntimeCall::Utility(_) |
-			RuntimeCall::Vesting(_) |
-			RuntimeCall::XTokens(_) |
-			RuntimeCall::Multisig(_) |
-			RuntimeCall::Identity(_) |
-			RuntimeCall::Contracts(_) |
-			RuntimeCall::ZenlinkProtocol(_) |
-			RuntimeCall::DiaOracleModule(_) |
-			RuntimeCall::Fee(_) |
-			RuntimeCall::Issue(_) |
-			RuntimeCall::Nomination(_) |
-			RuntimeCall::Oracle(_) |
-			RuntimeCall::Redeem(_) |
-			RuntimeCall::Replace(_) |
-			RuntimeCall::Security(_) |
-			RuntimeCall::StellarRelay(_) |
-			RuntimeCall::VaultRegistry(_) |
-			RuntimeCall::PooledVaultRewards(_) |
-			RuntimeCall::Farming(_) |
-			RuntimeCall::TokenAllowance(_) |
-			RuntimeCall::AssetRegistry(_) |
-			RuntimeCall::Proxy(_) |
-			RuntimeCall::OrmlExtension(_) |
-			RuntimeCall::TreasuryBuyoutExtension(_) |
-			RuntimeCall::RewardDistribution(_) => true, // All pallets are allowed, but exhaustive match is defensive
-			                                            // in the case of adding new pallets.
+			RuntimeCall::Bounties(_)
+			| RuntimeCall::ChildBounties(_)
+			| RuntimeCall::ClientsInfo(_)
+			| RuntimeCall::Treasury(_)
+			| RuntimeCall::Tokens(_)
+			| RuntimeCall::Currencies(_)
+			| RuntimeCall::ParachainStaking(_)
+			| RuntimeCall::Democracy(_)
+			| RuntimeCall::Council(_)
+			| RuntimeCall::TechnicalCommittee(_)
+			| RuntimeCall::System(_)
+			| RuntimeCall::Scheduler(_)
+			| RuntimeCall::Preimage(_)
+			| RuntimeCall::Timestamp(_)
+			| RuntimeCall::Balances(_)
+			| RuntimeCall::Session(_)
+			| RuntimeCall::ParachainSystem(_)
+			| RuntimeCall::Sudo(_)
+			| RuntimeCall::XcmpQueue(_)
+			| RuntimeCall::PolkadotXcm(_)
+			| RuntimeCall::DmpQueue(_)
+			| RuntimeCall::Utility(_)
+			| RuntimeCall::Vesting(_)
+			| RuntimeCall::XTokens(_)
+			| RuntimeCall::Multisig(_)
+			| RuntimeCall::Identity(_)
+			| RuntimeCall::Contracts(_)
+			| RuntimeCall::ZenlinkProtocol(_)
+			| RuntimeCall::DiaOracleModule(_)
+			| RuntimeCall::Fee(_)
+			| RuntimeCall::Issue(_)
+			| RuntimeCall::Nomination(_)
+			| RuntimeCall::Oracle(_)
+			| RuntimeCall::Redeem(_)
+			| RuntimeCall::Replace(_)
+			| RuntimeCall::Security(_)
+			| RuntimeCall::StellarRelay(_)
+			| RuntimeCall::VaultRegistry(_)
+			| RuntimeCall::PooledVaultRewards(_)
+			| RuntimeCall::Farming(_)
+			| RuntimeCall::TokenAllowance(_)
+			| RuntimeCall::AssetRegistry(_)
+			| RuntimeCall::Proxy(_)
+			| RuntimeCall::OrmlExtension(_)
+			| RuntimeCall::TreasuryBuyoutExtension(_)
+			| RuntimeCall::RewardDistribution(_) => true, // All pallets are allowed, but exhaustive match is defensive
+			                                              // in the case of adding new pallets.
 		}
 	}
 }

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -25,7 +25,7 @@ use codec::Encode;
 
 use smallvec::smallvec;
 use sp_api::impl_runtime_apis;
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H256};
+use sp_core::{crypto::KeyTypeId, Get, OpaqueMetadata, H256};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{
@@ -1037,22 +1037,24 @@ impl orml_tokens_management_extension::Config for Runtime {
 	type AssetDeposit = AssetDeposit;
 }
 
-pub struct OraclePriceGetter(Oracle);
-
+pub struct OraclePriceGetter(DiaOracleModule);
 impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	fn get_price<FixedNumber>(currency_id: CurrencyId) -> Result<FixedNumber, DispatchError>
 	where
 		FixedNumber: FixedPointNumber + One + Zero + Debug + TryFrom<FixedU128>,
 	{
-		let key = OracleKey::ExchangeRate(currency_id);
-		let asset_price = Oracle::get_price(key.clone())?;
+		let asset_metadata = AssetRegistry::metadata(currency_id)
+        .ok_or(DispatchError::Other("Asset not found"))?;
 
-		let converted_asset_price = FixedNumber::try_from(asset_price);
+		let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
+		let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
 
-		match converted_asset_price {
-			Ok(price) => Ok(price),
-			Err(_) => Err(DispatchError::Other("Failed to convert price")),
+		if let Ok(asset_info) = DiaOracleModule::get_coin_info(blockchain, symbol) {
+			let price = FixedNumber::try_from(FixedU128::from_inner(asset_info.price)).map_err(|_| DispatchError::Other("Failed to convert price"))?;
+			return Ok(price);
+		} else {
+			return Err(DispatchError::Other("Failed to get coin info"));
 		}
 	}
 	#[cfg(feature = "runtime-benchmarks")]
@@ -1063,28 +1065,19 @@ impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
 		// Forcefully set chain status to running when benchmarking so that the oracle doesn't fail
 		Security::set_status(StatusCode::Running);
 
-		let key = OracleKey::ExchangeRate(currency_id);
+		let asset_metadata = AssetRegistry::metadata(currency_id)
+        .ok_or(DispatchError::Other("Asset not found"))?;
 
-		// Attempt to get the price once and use the result to decide if feeding a value is necessary
-		match Oracle::get_price(key.clone()) {
-			Ok(asset_price) => {
-				// If the price is successfully retrieved, use it directly
-				let converted_asset_price = FixedNumber::try_from(asset_price)
-					.map_err(|_| DispatchError::Other("Failed to convert price"))?;
-				Ok(converted_asset_price)
-			},
-			Err(_) => {
-				// Price not found, feed the default value
-				let rate = FixedU128::checked_from_rational(100, 1).expect("This is a valid ratio");
-				// Account used for feeding values
-				let account = AccountId::from([0u8; 32]);
-				Oracle::feed_values(account, vec![(key.clone(), rate)])?;
+		let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
+		let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
 
-				// If feeding was successful, just use the feeded price to spare a read
-				let converted_asset_price = FixedNumber::try_from(rate)
-					.map_err(|_| DispatchError::Other("Failed to convert price"))?;
-				Ok(converted_asset_price)
-			},
+		if let Ok(asset_info) = DiaOracleModule::get_coin_info(blockchain, symbol) {
+			let price = FixedNumber::try_from(FixedU128::from_inner(asset_info.price)).map_err(|_| DispatchError::Other("Failed to convert price"))?;
+			Ok(price)
+		} else {
+			// Returning a default value in case fetching a real price from the oracle fails
+			let price = FixedNumber::checked_from_rational(100, 1).expect("This is a valid ratio");
+			Ok(price)
 		}
 	}
 }

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1037,51 +1037,6 @@ impl orml_tokens_management_extension::Config for Runtime {
 	type AssetDeposit = AssetDeposit;
 }
 
-pub struct OraclePriceGetter(DiaOracleModule);
-impl treasury_buyout_extension::PriceGetter<CurrencyId> for OraclePriceGetter {
-	#[cfg(not(feature = "runtime-benchmarks"))]
-	fn get_price<FixedNumber>(currency_id: CurrencyId) -> Result<FixedNumber, DispatchError>
-	where
-		FixedNumber: FixedPointNumber + One + Zero + Debug + TryFrom<FixedU128>,
-	{
-		let asset_metadata = AssetRegistry::metadata(currency_id)
-        .ok_or(DispatchError::Other("Asset not found"))?;
-
-		let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
-		let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
-
-		if let Ok(asset_info) = DiaOracleModule::get_coin_info(blockchain, symbol) {
-			let price = FixedNumber::try_from(FixedU128::from_inner(asset_info.price)).map_err(|_| DispatchError::Other("Failed to convert price"))?;
-			return Ok(price);
-		} else {
-			return Err(DispatchError::Other("Failed to get coin info"));
-		}
-	}
-	#[cfg(feature = "runtime-benchmarks")]
-	fn get_price<FixedNumber>(currency_id: CurrencyId) -> Result<FixedNumber, DispatchError>
-	where
-		FixedNumber: FixedPointNumber + One + Zero + Debug + TryFrom<FixedU128>,
-	{
-		// Forcefully set chain status to running when benchmarking so that the oracle doesn't fail
-		Security::set_status(StatusCode::Running);
-
-		let asset_metadata = AssetRegistry::metadata(currency_id)
-        .ok_or(DispatchError::Other("Asset not found"))?;
-
-		let blockchain = asset_metadata.additional.dia_keys.blockchain.into_inner();
-		let symbol = asset_metadata.additional.dia_keys.symbol.into_inner();
-
-		if let Ok(asset_info) = DiaOracleModule::get_coin_info(blockchain, symbol) {
-			let price = FixedNumber::try_from(FixedU128::from_inner(asset_info.price)).map_err(|_| DispatchError::Other("Failed to convert price"))?;
-			Ok(price)
-		} else {
-			// Returning a default value in case fetching a real price from the oracle fails
-			let price = FixedNumber::checked_from_rational(100, 1).expect("This is a valid ratio");
-			Ok(price)
-		}
-	}
-}
-
 pub struct DecimalsLookupImpl;
 impl spacewalk_primitives::DecimalsLookup for DecimalsLookupImpl {
 	type CurrencyId = CurrencyId;
@@ -1110,7 +1065,7 @@ impl treasury_buyout_extension::Config for Runtime {
 	type TreasuryAccount = FoucocoTreasuryAccount;
 	type BuyoutPeriod = BuyoutPeriod;
 	type SellFee = SellFee;
-	type PriceGetter = OraclePriceGetter;
+	type PriceGetter = runtime_common::OraclePriceGetter<Runtime>;
 	type DecimalsLookup = DecimalsLookupImpl;
 	type MinAmountToBuyout = MinAmountToBuyout;
 	type MaxAllowedBuyoutCurrencies = MaxAllowedBuyoutCurrencies;

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -7,10 +7,10 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 mod chain_ext;
+pub mod definitions;
 mod weights;
 pub mod xcm_config;
 pub mod zenlink;
-pub mod definitions;
 
 use crate::zenlink::*;
 use xcm::v3::MultiLocation;
@@ -30,7 +30,7 @@ use sp_runtime::{
 	},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, DispatchError, FixedPointNumber, MultiAddress, Perbill, Permill,
-	Perquintill, SaturatedConversion, 
+	Perquintill, SaturatedConversion,
 };
 
 use bifrost_farming as farming;
@@ -42,11 +42,10 @@ use spacewalk_primitives::{
 	UnsignedInner,
 };
 
-
 #[cfg(any(feature = "runtime-benchmarks", feature = "testing-utils"))]
 use oracle::testing_utils::MockDataFeeder;
 
-use sp_std::{marker::PhantomData, prelude::*, fmt::Debug};
+use sp_std::{fmt::Debug, marker::PhantomData, prelude::*};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
@@ -378,51 +377,51 @@ impl Contains<RuntimeCall> for BaseFilter {
 	fn contains(call: &RuntimeCall) -> bool {
 		match call {
 			// These modules are all allowed to be called by transactions:
-			RuntimeCall::Bounties(_) |
-			RuntimeCall::ChildBounties(_) |
-			RuntimeCall::ClientsInfo(_) |
-			RuntimeCall::Treasury(_) |
-			RuntimeCall::Tokens(_) |
-			RuntimeCall::Currencies(_) |
-			RuntimeCall::ParachainStaking(_) |
-			RuntimeCall::Democracy(_) |
-			RuntimeCall::Council(_) |
-			RuntimeCall::TechnicalCommittee(_) |
-			RuntimeCall::System(_) |
-			RuntimeCall::Scheduler(_) |
-			RuntimeCall::Preimage(_) |
-			RuntimeCall::Timestamp(_) |
-			RuntimeCall::Balances(_) |
-			RuntimeCall::Session(_) |
-			RuntimeCall::ParachainSystem(_) |
-			RuntimeCall::XcmpQueue(_) |
-			RuntimeCall::PolkadotXcm(_) |
-			RuntimeCall::DmpQueue(_) |
-			RuntimeCall::Utility(_) |
-			RuntimeCall::Vesting(_) |
-			RuntimeCall::XTokens(_) |
-			RuntimeCall::Multisig(_) |
-			RuntimeCall::Identity(_) |
-			RuntimeCall::Contracts(_) |
-			RuntimeCall::ZenlinkProtocol(_) |
-			RuntimeCall::DiaOracleModule(_) |
-			RuntimeCall::VestingManager(_) |
-			RuntimeCall::TokenAllowance(_) |
-			RuntimeCall::AssetRegistry(_) |
-			RuntimeCall::Fee(_) |
-			RuntimeCall::Issue(_) |
-			RuntimeCall::Nomination(_) |
-			RuntimeCall::Oracle(_) |
-			RuntimeCall::Redeem(_) |
-			RuntimeCall::Replace(_) |
-			RuntimeCall::Security(_) |
-			RuntimeCall::StellarRelay(_) |
-			RuntimeCall::VaultRegistry(_) |
-			RuntimeCall::PooledVaultRewards(_) |
-			RuntimeCall::RewardDistribution(_) |
-			RuntimeCall::Farming(_) |
-			RuntimeCall::Proxy(_) |
-			RuntimeCall::TreasuryBuyoutExtension(_) => true,
+			RuntimeCall::Bounties(_)
+			| RuntimeCall::ChildBounties(_)
+			| RuntimeCall::ClientsInfo(_)
+			| RuntimeCall::Treasury(_)
+			| RuntimeCall::Tokens(_)
+			| RuntimeCall::Currencies(_)
+			| RuntimeCall::ParachainStaking(_)
+			| RuntimeCall::Democracy(_)
+			| RuntimeCall::Council(_)
+			| RuntimeCall::TechnicalCommittee(_)
+			| RuntimeCall::System(_)
+			| RuntimeCall::Scheduler(_)
+			| RuntimeCall::Preimage(_)
+			| RuntimeCall::Timestamp(_)
+			| RuntimeCall::Balances(_)
+			| RuntimeCall::Session(_)
+			| RuntimeCall::ParachainSystem(_)
+			| RuntimeCall::XcmpQueue(_)
+			| RuntimeCall::PolkadotXcm(_)
+			| RuntimeCall::DmpQueue(_)
+			| RuntimeCall::Utility(_)
+			| RuntimeCall::Vesting(_)
+			| RuntimeCall::XTokens(_)
+			| RuntimeCall::Multisig(_)
+			| RuntimeCall::Identity(_)
+			| RuntimeCall::Contracts(_)
+			| RuntimeCall::ZenlinkProtocol(_)
+			| RuntimeCall::DiaOracleModule(_)
+			| RuntimeCall::VestingManager(_)
+			| RuntimeCall::TokenAllowance(_)
+			| RuntimeCall::AssetRegistry(_)
+			| RuntimeCall::Fee(_)
+			| RuntimeCall::Issue(_)
+			| RuntimeCall::Nomination(_)
+			| RuntimeCall::Oracle(_)
+			| RuntimeCall::Redeem(_)
+			| RuntimeCall::Replace(_)
+			| RuntimeCall::Security(_)
+			| RuntimeCall::StellarRelay(_)
+			| RuntimeCall::VaultRegistry(_)
+			| RuntimeCall::PooledVaultRewards(_)
+			| RuntimeCall::RewardDistribution(_)
+			| RuntimeCall::Farming(_)
+			| RuntimeCall::Proxy(_)
+			| RuntimeCall::TreasuryBuyoutExtension(_) => true,
 			// All pallets are allowed, but exhaustive match is defensive
 			// in the case of adding new pallets.
 		}

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -27,11 +27,10 @@ use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{
 		AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, Convert, ConvertInto,
-		Zero, One,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, DispatchError, FixedPointNumber, MultiAddress, Perbill, Permill,
-	Perquintill, SaturatedConversion, FixedU128, 
+	Perquintill, SaturatedConversion, 
 };
 
 use bifrost_farming as farming;
@@ -85,7 +84,6 @@ pub use nomination::Event as NominationEvent;
 use oracle::{
 	dia,
 	dia::{DiaOracleAdapter, NativeCurrencyKey, XCMCurrencyConversion},
-	OracleKey,
 };
 pub use redeem::{Event as RedeemEvent, RedeemRequest};
 pub use replace::{Event as ReplaceEvent, ReplaceRequest};


### PR DESCRIPTION
This PR modifies `PriceGetter` trait implementation by replacing usage of `oracle` pallet with `dia-oracle`. 
`PriceGetter` is a trait that is used to fetch prices of assets when doing buyouts.

Closes #445. 

