### PR TITLE
Bump Foucoco spec version

### DIFF
--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -274,7 +274,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("foucoco"),
 	impl_name: create_runtime_str!("foucoco"),
 	authoring_version: 1,
-	spec_version: 17,
+	spec_version: 18,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 8,


### PR DESCRIPTION
Closes #475.

Compressed wasm used for the upgrade:
[foucoco_runtime.compact.compressed.wasm.zip](https://github.com/pendulum-chain/pendulum/files/15354257/foucoco_runtime.compact.compressed.wasm.zip)

Code hash:
`0xdbf426cb9c9a116a4b2cb0309c20053aff2a5f184b4cddab47fb6fefef222792`