### PR TITLE
Implement pallet for mock-skip blocks on runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6989,6 +6989,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-contracts-test"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-contracts",
+ "pallet-contracts-primitives",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3194,6 +3194,7 @@ dependencies = [
  "pallet-democracy",
  "pallet-identity",
  "pallet-insecure-randomness-collective-flip",
+ "pallet-mock-skip-blocks",
  "pallet-multisig",
  "pallet-preimage",
  "pallet-proxy",
@@ -7214,6 +7215,21 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-mmr-primitives",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-mock-skip-blocks"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
  "sp-runtime",
  "sp-std",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7231,7 +7231,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 	"runtime/integration-tests",
 	"chain-extensions/token",
 	"chain-extensions/price",
-	"chain-extensions/common",
+	"chain-extensions/common", "pallets/pallet-mock-skip-blocks",
 ]
 
 # need this because of bifrost farming dependency in runtime

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -113,3 +113,5 @@ try-runtime = [
     "pendulum-runtime/try-runtime",
     "try-runtime-cli/try-runtime"
 ]
+
+instant-seal = ["foucoco-runtime/instant-seal"]

--- a/pallets/pallet-mock-skip-blocks/Cargo.toml
+++ b/pallets/pallet-mock-skip-blocks/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 default = ["std"]
 std = [
     "frame-system/std",
+    "frame-support/std",
 ]
 
 instant-seal = ["std"]
@@ -17,9 +18,8 @@ scale-info = { version = "2.2.0", default-features = false, features = ["derive"
 serde = { version = "1.0.130", default-features = false, features = ["derive"], optional = true }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
 
 [dev-dependencies]
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }

--- a/pallets/pallet-mock-skip-blocks/Cargo.toml
+++ b/pallets/pallet-mock-skip-blocks/Cargo.toml
@@ -10,14 +10,16 @@ std = [
     "frame-support/std",
 ]
 
-instant-seal = ["std"]
+instant-seal = []
 
 [dependencies]
+# hex-literal = { version = "0.3.4", optional = true }
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.130", default-features = false, features = ["derive"], optional = true }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
 
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }

--- a/pallets/pallet-mock-skip-blocks/Cargo.toml
+++ b/pallets/pallet-mock-skip-blocks/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "pallet-mock-skip-blocks"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["std"]
+std = [
+    "frame-system/std",
+]
+
+instant-seal = ["std"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.130", default-features = false, features = ["derive"], optional = true }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
+
+[dev-dependencies]
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }

--- a/pallets/pallet-mock-skip-blocks/src/lib.rs
+++ b/pallets/pallet-mock-skip-blocks/src/lib.rs
@@ -1,0 +1,110 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "instant-seal")]
+pub use pallet::*;
+
+#[cfg(not(feature = "instant-seal"))]
+pub use dummy as pallet;
+
+#[cfg(not(feature = "instant-seal"))]
+#[frame_support::pallet]
+pub mod dummy {
+	use frame_support::pallet_prelude::*;
+
+    #[pallet::pallet]
+    pub struct Pallet<T>(_);
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {        
+        /// Dummy event
+       DummyEvent,
+	}
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+		/// Overarching event type
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+	}
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {}
+}
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(feature = "instant-seal")]
+#[frame_support::pallet]
+pub mod pallet {
+    use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
+    use frame_system::pallet_prelude::*;
+
+    #[pallet::pallet]
+    pub struct Pallet<T>(PhantomData<T>);
+
+    #[pallet::error]
+    pub enum Error<T> {
+        InvalidBlockNumber,
+    }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {        
+        /// Desired block number stored
+        DesiredBlockStored { n: BlockNumberFor<T>},
+        /// Desired block number set
+        BlockSet { n: BlockNumberFor<T>},
+        /// Original block number restored
+        BlockReverted { n: BlockNumberFor<T>},
+    }
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+        fn on_initialize(n: T::BlockNumber) -> Weight {
+            let desired_block_number = DesiredBlockNumber::<T>::get();
+            OriginalBlockNumber::<T>::put(n);
+            frame_system::Pallet::<T>::set_block_number(desired_block_number);
+            Self::deposit_event(Event::<T>::BlockSet { n: desired_block_number });
+            0.into()
+        }
+
+        fn on_finalize(_: T::BlockNumber) {
+            let original_block_number = OriginalBlockNumber::<T>::get();
+            frame_system::Pallet::<T>::set_block_number(original_block_number);
+            Self::deposit_event(Event::<T>::BlockReverted { n: original_block_number });
+        }
+    }
+
+    #[pallet::storage]
+    pub type DesiredBlockNumber<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
+
+    #[pallet::storage]
+    pub type OriginalBlockNumber<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
+    
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// Overarching event type
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        #[pallet::call_index(0)]
+        #[pallet::weight((0, Pays::No))]
+        pub fn set_block_number(origin: OriginFor<T>, block_number: T::BlockNumber) -> DispatchResult {
+            ensure_root(origin)?;
+
+            let current_block_number = frame_system::Pallet::<T>::block_number();
+            ensure!(block_number >= current_block_number, Error::<T>::InvalidBlockNumber);
+
+            DesiredBlockNumber::<T>::put(block_number);
+            Self::deposit_event(Event::<T>::DesiredBlockStored { n: block_number });
+
+            Ok(())
+        }
+    }
+}

--- a/pallets/pallet-mock-skip-blocks/src/lib.rs
+++ b/pallets/pallet-mock-skip-blocks/src/lib.rs
@@ -1,44 +1,44 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "instant-seal"))]
-pub use dummy as pallet;
+// #[cfg(not(feature = "instant-seal"))]
+// pub use dummy as pallet;
 
 pub use pallet::*;
 
-#[cfg(not(feature = "instant-seal"))]
-#[frame_support::pallet]
-pub mod dummy {
-	use frame_support::pallet_prelude::*;
+// #[cfg(not(feature = "instant-seal"))]
+// #[frame_support::pallet]
+// pub mod dummy {
+// 	use frame_support::pallet_prelude::*;
+//
+// 	#[pallet::pallet]
+// 	pub struct Pallet<T>(_);
+//
+// 	#[pallet::event]
+// 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+// 	pub enum Event<T: Config> {
+// 		/// Dummy event
+// 		DummyEvent,
+// 	}
+//
+// 	#[pallet::config]
+// 	pub trait Config: frame_system::Config {
+// 		/// Overarching event type
+// 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+// 	}
+//
+// 	#[pallet::call]
+// 	impl<T: Config> Pallet<T> {}
+// }
 
-	#[pallet::pallet]
-	pub struct Pallet<T>(_);
-
-	#[pallet::event]
-	#[pallet::generate_deposit(pub(super) fn deposit_event)]
-	pub enum Event<T: Config> {
-		/// Dummy event
-		DummyEvent,
-	}
-
-	#[pallet::config]
-	pub trait Config: frame_system::Config {
-		/// Overarching event type
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-	}
-
-	#[pallet::call]
-	impl<T: Config> Pallet<T> {}
-}
-
-#[cfg(feature = "instant-seal")]
+//#[cfg(feature = "instant-seal")]
 #[cfg(test)]
 mod mock;
 
-#[cfg(feature = "instant-seal")]
+//#[cfg(feature = "instant-seal")]
 #[cfg(test)]
 mod tests;
 
-#[cfg(feature = "instant-seal")]
+//#[cfg(feature = "instant-seal")]
 #[frame_support::pallet]
 pub mod pallet {
 	use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
@@ -51,6 +51,14 @@ pub mod pallet {
 	pub enum Error<T> {
 		InvalidBlockNumber,
 	}
+
+	//const ENCODED_KEY: &[u8] = &hex_literal::hex!("0x26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac");
+
+	const ENCODED_KEY: &[u8] = &[
+		0x26, 0xaa, 0x39, 0x4e, 0xea, 0x56, 0x30, 0xe0, 0x7c, 0x48, 0xae, 0x0c,
+		0x95, 0x58, 0xce, 0xf7, 0x02, 0xa5, 0xc1, 0xb1, 0x9a, 0xb7, 0xa0, 0x4f,
+		0x53, 0x6c, 0x51, 0x9a, 0xca, 0x49, 0x83, 0xac,
+	];
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
@@ -68,14 +76,16 @@ pub mod pallet {
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			let desired_block_number = DesiredBlockNumber::<T>::get();
 			OriginalBlockNumber::<T>::put(n);
-			frame_system::Pallet::<T>::set_block_number(desired_block_number);
+			//frame_system::Pallet::<T>::set_block_number(desired_block_number);
+			sp_io::storage::set(ENCODED_KEY, &*desired_block_number.encode());
 			Self::deposit_event(Event::<T>::BlockSet { n: desired_block_number });
-			0.into()
+			Weight::from_ref_time(0)
 		}
 
 		fn on_finalize(_: T::BlockNumber) {
 			let original_block_number = OriginalBlockNumber::<T>::get();
-			frame_system::Pallet::<T>::set_block_number(original_block_number);
+			//frame_system::Pallet::<T>::set_block_number(original_block_number);
+			sp_io::storage::set(ENCODED_KEY, &*original_block_number.encode());
 			Self::deposit_event(Event::<T>::BlockReverted { n: original_block_number });
 		}
 	}

--- a/pallets/pallet-mock-skip-blocks/src/lib.rs
+++ b/pallets/pallet-mock-skip-blocks/src/lib.rs
@@ -11,24 +11,24 @@ pub use dummy as pallet;
 pub mod dummy {
 	use frame_support::pallet_prelude::*;
 
-    #[pallet::pallet]
-    pub struct Pallet<T>(_);
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
-	pub enum Event<T: Config> {        
-        /// Dummy event
-       DummyEvent,
+	pub enum Event<T: Config> {
+		/// Dummy event
+		DummyEvent,
 	}
 
-    #[pallet::config]
-    pub trait Config: frame_system::Config {
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
 		/// Overarching event type
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 	}
 
-    #[pallet::call]
-    impl<T: Config> Pallet<T> {}
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
 }
 
 #[cfg(test)]
@@ -40,71 +40,74 @@ mod tests;
 #[cfg(feature = "instant-seal")]
 #[frame_support::pallet]
 pub mod pallet {
-    use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
-    use frame_system::pallet_prelude::*;
+	use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
+	use frame_system::pallet_prelude::*;
 
-    #[pallet::pallet]
-    pub struct Pallet<T>(PhantomData<T>);
+	#[pallet::pallet]
+	pub struct Pallet<T>(PhantomData<T>);
 
-    #[pallet::error]
-    pub enum Error<T> {
-        InvalidBlockNumber,
-    }
+	#[pallet::error]
+	pub enum Error<T> {
+		InvalidBlockNumber,
+	}
 
-    #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    pub enum Event<T: Config> {        
-        /// Desired block number stored
-        DesiredBlockStored { n: BlockNumberFor<T>},
-        /// Desired block number set
-        BlockSet { n: BlockNumberFor<T>},
-        /// Original block number restored
-        BlockReverted { n: BlockNumberFor<T>},
-    }
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Desired block number stored
+		DesiredBlockStored { n: BlockNumberFor<T> },
+		/// Desired block number set
+		BlockSet { n: BlockNumberFor<T> },
+		/// Original block number restored
+		BlockReverted { n: BlockNumberFor<T> },
+	}
 
-    #[pallet::hooks]
-    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-        fn on_initialize(n: T::BlockNumber) -> Weight {
-            let desired_block_number = DesiredBlockNumber::<T>::get();
-            OriginalBlockNumber::<T>::put(n);
-            frame_system::Pallet::<T>::set_block_number(desired_block_number);
-            Self::deposit_event(Event::<T>::BlockSet { n: desired_block_number });
-            0.into()
-        }
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_initialize(n: T::BlockNumber) -> Weight {
+			let desired_block_number = DesiredBlockNumber::<T>::get();
+			OriginalBlockNumber::<T>::put(n);
+			frame_system::Pallet::<T>::set_block_number(desired_block_number);
+			Self::deposit_event(Event::<T>::BlockSet { n: desired_block_number });
+			0.into()
+		}
 
-        fn on_finalize(_: T::BlockNumber) {
-            let original_block_number = OriginalBlockNumber::<T>::get();
-            frame_system::Pallet::<T>::set_block_number(original_block_number);
-            Self::deposit_event(Event::<T>::BlockReverted { n: original_block_number });
-        }
-    }
+		fn on_finalize(_: T::BlockNumber) {
+			let original_block_number = OriginalBlockNumber::<T>::get();
+			frame_system::Pallet::<T>::set_block_number(original_block_number);
+			Self::deposit_event(Event::<T>::BlockReverted { n: original_block_number });
+		}
+	}
 
-    #[pallet::storage]
-    pub type DesiredBlockNumber<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
+	#[pallet::storage]
+	pub type DesiredBlockNumber<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
 
-    #[pallet::storage]
-    pub type OriginalBlockNumber<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
-    
-    #[pallet::config]
-    pub trait Config: frame_system::Config {
-        /// Overarching event type
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-    }
+	#[pallet::storage]
+	pub type OriginalBlockNumber<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
 
-    #[pallet::call]
-    impl<T: Config> Pallet<T> {
-        #[pallet::call_index(0)]
-        #[pallet::weight((0, Pays::No))]
-        pub fn set_block_number(origin: OriginFor<T>, block_number: T::BlockNumber) -> DispatchResult {
-            ensure_root(origin)?;
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// Overarching event type
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+	}
 
-            let current_block_number = frame_system::Pallet::<T>::block_number();
-            ensure!(block_number >= current_block_number, Error::<T>::InvalidBlockNumber);
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
+		#[pallet::weight((0, Pays::No))]
+		pub fn set_block_number(
+			origin: OriginFor<T>,
+			block_number: T::BlockNumber,
+		) -> DispatchResult {
+			ensure_root(origin)?;
 
-            DesiredBlockNumber::<T>::put(block_number);
-            Self::deposit_event(Event::<T>::DesiredBlockStored { n: block_number });
+			let current_block_number = frame_system::Pallet::<T>::block_number();
+			ensure!(block_number >= current_block_number, Error::<T>::InvalidBlockNumber);
 
-            Ok(())
-        }
-    }
+			DesiredBlockNumber::<T>::put(block_number);
+			Self::deposit_event(Event::<T>::DesiredBlockStored { n: block_number });
+
+			Ok(())
+		}
+	}
 }

--- a/pallets/pallet-mock-skip-blocks/src/lib.rs
+++ b/pallets/pallet-mock-skip-blocks/src/lib.rs
@@ -31,9 +31,11 @@ pub mod dummy {
 	impl<T: Config> Pallet<T> {}
 }
 
+#[cfg(feature = "instant-seal")]
 #[cfg(test)]
 mod mock;
 
+#[cfg(feature = "instant-seal")]
 #[cfg(test)]
 mod tests;
 

--- a/pallets/pallet-mock-skip-blocks/src/lib.rs
+++ b/pallets/pallet-mock-skip-blocks/src/lib.rs
@@ -1,10 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "instant-seal")]
-pub use pallet::*;
-
 #[cfg(not(feature = "instant-seal"))]
 pub use dummy as pallet;
+
+pub use pallet::*;
 
 #[cfg(not(feature = "instant-seal"))]
 #[frame_support::pallet]

--- a/pallets/pallet-mock-skip-blocks/src/mock.rs
+++ b/pallets/pallet-mock-skip-blocks/src/mock.rs
@@ -1,18 +1,13 @@
 #[cfg(feature = "instant-seal")]
-use crate::{
-    self as pallet_mock_skip_blocks, Config,
-};
+use crate::{self as pallet_mock_skip_blocks, Config};
 #[cfg(feature = "instant-seal")]
-use frame_support::{
-    parameter_types,
-    traits::Everything,
-};
+use frame_support::{parameter_types, traits::Everything};
 #[cfg(feature = "instant-seal")]
 use sp_core::H256;
 #[cfg(feature = "instant-seal")]
 use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
 };
 
 #[cfg(feature = "instant-seal")]
@@ -23,14 +18,14 @@ type Block = frame_system::mocking::MockBlock<Test>;
 // Configure a mock runtime to test the pallet.
 #[cfg(feature = "instant-seal")]
 frame_support::construct_runtime!(
-    pub enum Test where
-        Block = Block,
-        NodeBlock = Block,
-        UncheckedExtrinsic = UncheckedExtrinsic,
-    {
-        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
-        MockSkipBlocks: pallet_mock_skip_blocks::{Pallet, Storage, Call, Event<T>},
-    }
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+		MockSkipBlocks: pallet_mock_skip_blocks::{Pallet, Storage, Call, Event<T>},
+	}
 );
 
 #[cfg(feature = "instant-seal")]
@@ -42,8 +37,8 @@ pub type Index = u64;
 
 #[cfg(feature = "instant-seal")]
 parameter_types! {
-    pub const BlockHashCount: u64 = 250;
-    pub const SS58Prefix: u8 = 42;
+	pub const BlockHashCount: u64 = 250;
+	pub const SS58Prefix: u8 = 42;
 }
 
 #[cfg(feature = "instant-seal")]
@@ -51,35 +46,35 @@ pub type TestEvent = RuntimeEvent;
 
 #[cfg(feature = "instant-seal")]
 impl frame_system::Config for Test {
-    type BaseCallFilter = Everything;
-    type BlockWeights = ();
-    type BlockLength = ();
-    type DbWeight = ();
-    type RuntimeOrigin = RuntimeOrigin;
-    type RuntimeCall = RuntimeCall;
-    type Index = Index;
-    type BlockNumber = BlockNumber;
-    type Hash = H256;
-    type Hashing = BlakeTwo256;
-    type AccountId = AccountId;
-    type Lookup = IdentityLookup<Self::AccountId>;
-    type Header = Header;
-    type RuntimeEvent = TestEvent;
-    type BlockHashCount = BlockHashCount;
-    type Version = ();
-    type PalletInfo = PalletInfo;
-    type AccountData = ();
-    type OnNewAccount = ();
-    type OnKilledAccount = ();
-    type SystemWeightInfo = ();
-    type SS58Prefix = SS58Prefix;
-    type OnSetCode = ();
-    type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type BaseCallFilter = Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Index = Index;
+	type BlockNumber = BlockNumber;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type RuntimeEvent = TestEvent;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 #[cfg(feature = "instant-seal")]
 impl Config for Test {
-    type RuntimeEvent = RuntimeEvent;
+	type RuntimeEvent = RuntimeEvent;
 }
 
 #[cfg(feature = "instant-seal")]
@@ -87,19 +82,19 @@ pub struct ExtBuilder;
 
 #[cfg(feature = "instant-seal")]
 impl ExtBuilder {
-    pub fn build() -> sp_io::TestExternalities {
-        let storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-        sp_io::TestExternalities::from(storage)
-    }
+	pub fn build() -> sp_io::TestExternalities {
+		let storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+		sp_io::TestExternalities::from(storage)
+	}
 }
 
 #[cfg(feature = "instant-seal")]
 pub fn run_test<T>(test: T)
 where
-    T: FnOnce(),
+	T: FnOnce(),
 {
-    ExtBuilder::build().execute_with(|| {
-        System::set_block_number(1);
-        test();
-    });
+	ExtBuilder::build().execute_with(|| {
+		System::set_block_number(1);
+		test();
+	});
 }

--- a/pallets/pallet-mock-skip-blocks/src/mock.rs
+++ b/pallets/pallet-mock-skip-blocks/src/mock.rs
@@ -1,0 +1,105 @@
+#[cfg(feature = "instant-seal")]
+use crate::{
+    self as pallet_mock_skip_blocks, Config,
+};
+#[cfg(feature = "instant-seal")]
+use frame_support::{
+    parameter_types,
+    traits::Everything,
+};
+#[cfg(feature = "instant-seal")]
+use sp_core::H256;
+#[cfg(feature = "instant-seal")]
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+};
+
+#[cfg(feature = "instant-seal")]
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+#[cfg(feature = "instant-seal")]
+type Block = frame_system::mocking::MockBlock<Test>;
+
+// Configure a mock runtime to test the pallet.
+#[cfg(feature = "instant-seal")]
+frame_support::construct_runtime!(
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        MockSkipBlocks: pallet_mock_skip_blocks::{Pallet, Storage, Call, Event<T>},
+    }
+);
+
+#[cfg(feature = "instant-seal")]
+pub type AccountId = u64;
+#[cfg(feature = "instant-seal")]
+pub type BlockNumber = u64;
+#[cfg(feature = "instant-seal")]
+pub type Index = u64;
+
+#[cfg(feature = "instant-seal")]
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const SS58Prefix: u8 = 42;
+}
+
+#[cfg(feature = "instant-seal")]
+pub type TestEvent = RuntimeEvent;
+
+#[cfg(feature = "instant-seal")]
+impl frame_system::Config for Test {
+    type BaseCallFilter = Everything;
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type Index = Index;
+    type BlockNumber = BlockNumber;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type RuntimeEvent = TestEvent;
+    type BlockHashCount = BlockHashCount;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = SS58Prefix;
+    type OnSetCode = ();
+    type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+#[cfg(feature = "instant-seal")]
+impl Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+}
+
+#[cfg(feature = "instant-seal")]
+pub struct ExtBuilder;
+
+#[cfg(feature = "instant-seal")]
+impl ExtBuilder {
+    pub fn build() -> sp_io::TestExternalities {
+        let storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+        sp_io::TestExternalities::from(storage)
+    }
+}
+
+#[cfg(feature = "instant-seal")]
+pub fn run_test<T>(test: T)
+where
+    T: FnOnce(),
+{
+    ExtBuilder::build().execute_with(|| {
+        System::set_block_number(1);
+        test();
+    });
+}

--- a/pallets/pallet-mock-skip-blocks/src/mock.rs
+++ b/pallets/pallet-mock-skip-blocks/src/mock.rs
@@ -1,22 +1,15 @@
-#[cfg(feature = "instant-seal")]
 use crate::{self as pallet_mock_skip_blocks, Config};
-#[cfg(feature = "instant-seal")]
 use frame_support::{parameter_types, traits::Everything};
-#[cfg(feature = "instant-seal")]
 use sp_core::H256;
-#[cfg(feature = "instant-seal")]
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-#[cfg(feature = "instant-seal")]
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
-#[cfg(feature = "instant-seal")]
 type Block = frame_system::mocking::MockBlock<Test>;
 
 // Configure a mock runtime to test the pallet.
-#[cfg(feature = "instant-seal")]
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
@@ -28,23 +21,17 @@ frame_support::construct_runtime!(
 	}
 );
 
-#[cfg(feature = "instant-seal")]
 pub type AccountId = u64;
-#[cfg(feature = "instant-seal")]
 pub type BlockNumber = u64;
-#[cfg(feature = "instant-seal")]
 pub type Index = u64;
 
-#[cfg(feature = "instant-seal")]
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub const SS58Prefix: u8 = 42;
 }
 
-#[cfg(feature = "instant-seal")]
 pub type TestEvent = RuntimeEvent;
 
-#[cfg(feature = "instant-seal")]
 impl frame_system::Config for Test {
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
@@ -72,15 +59,12 @@ impl frame_system::Config for Test {
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
-#[cfg(feature = "instant-seal")]
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 }
 
-#[cfg(feature = "instant-seal")]
 pub struct ExtBuilder;
 
-#[cfg(feature = "instant-seal")]
 impl ExtBuilder {
 	pub fn build() -> sp_io::TestExternalities {
 		let storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
@@ -88,7 +72,6 @@ impl ExtBuilder {
 	}
 }
 
-#[cfg(feature = "instant-seal")]
 pub fn run_test<T>(test: T)
 where
 	T: FnOnce(),

--- a/pallets/pallet-mock-skip-blocks/src/tests.rs
+++ b/pallets/pallet-mock-skip-blocks/src/tests.rs
@@ -1,0 +1,58 @@
+#![cfg(test)]
+#[cfg(feature = "instant-seal")]
+use crate::{
+    mock::*,
+    Error,
+};
+#[cfg(feature = "instant-seal")]
+use frame_support::{assert_noop, assert_ok, traits::Hooks};
+
+#[cfg(feature = "instant-seal")]
+#[test]
+fn sets_and_reverts_block_number_success() {
+    run_test(|| {
+        // Initial block number
+        assert_eq!(System::block_number(), 1);
+
+        // Set desired block number
+        let desired_block_number = 95;
+        assert_ok!(crate::Pallet::<Test>::set_block_number(RuntimeOrigin::root(), desired_block_number));
+
+        // Simulate block production
+        System::on_initialize(1);
+        crate::Pallet::<Test>::on_initialize(1);
+        assert_eq!(System::block_number(), desired_block_number);
+
+        crate::Pallet::<Test>::on_finalize(1);
+        System::on_finalize(1);
+        assert_eq!(System::block_number(), 1);
+
+        // Advance to the next block
+        System::set_block_number(2);
+        System::on_initialize(2);
+        crate::Pallet::<Test>::on_initialize(2);
+        assert_eq!(System::block_number(), desired_block_number);
+
+        crate::Pallet::<Test>::on_finalize(2);
+        System::on_finalize(2);
+        assert_eq!(System::block_number(), 2);
+    });
+}
+
+#[cfg(feature = "instant-seal")]
+#[test]
+fn setting_block_number_to_less_than_current_fails() {
+    run_test(|| {
+        // Initial block number
+        assert_eq!(System::block_number(), 1);
+
+        // Attempt to set desired block number to a value less than the current block number
+        assert_noop!(
+            crate::Pallet::<Test>::set_block_number(RuntimeOrigin::root(), 0),
+            Error::<Test>::InvalidBlockNumber
+        );
+
+        // Block number should remain unchanged
+        assert_eq!(System::block_number(), 1);
+    });
+}

--- a/pallets/pallet-mock-skip-blocks/src/tests.rs
+++ b/pallets/pallet-mock-skip-blocks/src/tests.rs
@@ -1,10 +1,7 @@
 #![cfg(test)]
-#[cfg(feature = "instant-seal")]
 use crate::{mock::*, Error};
-#[cfg(feature = "instant-seal")]
 use frame_support::{assert_noop, assert_ok, traits::Hooks};
 
-#[cfg(feature = "instant-seal")]
 #[test]
 fn sets_and_reverts_block_number_success() {
 	run_test(|| {
@@ -39,7 +36,6 @@ fn sets_and_reverts_block_number_success() {
 	});
 }
 
-#[cfg(feature = "instant-seal")]
 #[test]
 fn setting_block_number_to_less_than_current_fails() {
 	run_test(|| {

--- a/pallets/pallet-mock-skip-blocks/src/tests.rs
+++ b/pallets/pallet-mock-skip-blocks/src/tests.rs
@@ -1,58 +1,58 @@
 #![cfg(test)]
 #[cfg(feature = "instant-seal")]
-use crate::{
-    mock::*,
-    Error,
-};
+use crate::{mock::*, Error};
 #[cfg(feature = "instant-seal")]
 use frame_support::{assert_noop, assert_ok, traits::Hooks};
 
 #[cfg(feature = "instant-seal")]
 #[test]
 fn sets_and_reverts_block_number_success() {
-    run_test(|| {
-        // Initial block number
-        assert_eq!(System::block_number(), 1);
+	run_test(|| {
+		// Initial block number
+		assert_eq!(System::block_number(), 1);
 
-        // Set desired block number
-        let desired_block_number = 95;
-        assert_ok!(crate::Pallet::<Test>::set_block_number(RuntimeOrigin::root(), desired_block_number));
+		// Set desired block number
+		let desired_block_number = 95;
+		assert_ok!(crate::Pallet::<Test>::set_block_number(
+			RuntimeOrigin::root(),
+			desired_block_number
+		));
 
-        // Simulate block production
-        System::on_initialize(1);
-        crate::Pallet::<Test>::on_initialize(1);
-        assert_eq!(System::block_number(), desired_block_number);
+		// Simulate block production
+		System::on_initialize(1);
+		crate::Pallet::<Test>::on_initialize(1);
+		assert_eq!(System::block_number(), desired_block_number);
 
-        crate::Pallet::<Test>::on_finalize(1);
-        System::on_finalize(1);
-        assert_eq!(System::block_number(), 1);
+		crate::Pallet::<Test>::on_finalize(1);
+		System::on_finalize(1);
+		assert_eq!(System::block_number(), 1);
 
-        // Advance to the next block
-        System::set_block_number(2);
-        System::on_initialize(2);
-        crate::Pallet::<Test>::on_initialize(2);
-        assert_eq!(System::block_number(), desired_block_number);
+		// Advance to the next block
+		System::set_block_number(2);
+		System::on_initialize(2);
+		crate::Pallet::<Test>::on_initialize(2);
+		assert_eq!(System::block_number(), desired_block_number);
 
-        crate::Pallet::<Test>::on_finalize(2);
-        System::on_finalize(2);
-        assert_eq!(System::block_number(), 2);
-    });
+		crate::Pallet::<Test>::on_finalize(2);
+		System::on_finalize(2);
+		assert_eq!(System::block_number(), 2);
+	});
 }
 
 #[cfg(feature = "instant-seal")]
 #[test]
 fn setting_block_number_to_less_than_current_fails() {
-    run_test(|| {
-        // Initial block number
-        assert_eq!(System::block_number(), 1);
+	run_test(|| {
+		// Initial block number
+		assert_eq!(System::block_number(), 1);
 
-        // Attempt to set desired block number to a value less than the current block number
-        assert_noop!(
-            crate::Pallet::<Test>::set_block_number(RuntimeOrigin::root(), 0),
-            Error::<Test>::InvalidBlockNumber
-        );
+		// Attempt to set desired block number to a value less than the current block number
+		assert_noop!(
+			crate::Pallet::<Test>::set_block_number(RuntimeOrigin::root(), 0),
+			Error::<Test>::InvalidBlockNumber
+		);
 
-        // Block number should remain unchanged
-        assert_eq!(System::block_number(), 1);
-    });
+		// Block number should remain unchanged
+		assert_eq!(System::block_number(), 1);
+	});
 }

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -110,6 +110,7 @@ parachain-staking = { path = "../../pallets/parachain-staking", default-features
 orml-currencies-allowance-extension = { path = "../../pallets/orml-currencies-allowance-extension", default-features = false }
 orml-tokens-management-extension = { path = "../../pallets/orml-tokens-management-extension", default-features = false }
 treasury-buyout-extension = { path = "../../pallets/treasury-buyout-extension", default-features = false }
+pallet-mock-skip-blocks = { path = "../../pallets/pallet-mock-skip-blocks", default-features = false }
 
 # DIA
 dia-oracle = { git = "https://github.com/pendulum-chain/oracle-pallet", default-features = false, branch = "polkadot-v0.9.42" }
@@ -337,4 +338,8 @@ try-runtime = [
     "treasury-buyout-extension/try-runtime",
     "bifrost-farming/try-runtime",
     "zenlink-protocol/try-runtime",
+]
+
+instant-seal = [
+    "pallet-mock-skip-blocks/instant-seal",
 ]

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1414,17 +1414,27 @@ impl pallet_proxy::Config for Runtime {
 	type AnnouncementDepositFactor = AnnouncementDepositFactor;
 }
 
-cfg_if::cfg_if! {
-	if #[cfg(feature = "instant-seal")] {
-		impl pallet_mock_skip_blocks::Config for Runtime {
-			type RuntimeEvent = RuntimeEvent;
-		}
-	} else {
-		impl pallet_mock_skip_blocks::dummy::Config for Runtime {
-			type RuntimeEvent = RuntimeEvent;
-		}
-	}
+// cfg_if::cfg_if! {
+// 	if #[cfg(feature = "instant-seal")] {
+// 		impl pallet_mock_skip_blocks::Config for Runtime {
+// 			type RuntimeEvent = RuntimeEvent;
+// 		}
+// 	} else {
+// 		impl pallet_mock_skip_blocks::dummy::Config for Runtime {
+// 			type RuntimeEvent = RuntimeEvent;
+// 		}
+// 	}
+// }
+
+//#[cfg(feature = "instant-seal")]
+impl pallet_mock_skip_blocks::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
 }
+
+// #[cfg(not(feature = "instant-seal"))]
+// impl pallet_mock_skip_blocks::dummy::Config for Runtime {
+// 	type RuntimeEvent = RuntimeEvent;
+// }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
 where

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -374,6 +374,7 @@ impl Contains<RuntimeCall> for BaseFilter {
 			| RuntimeCall::Proxy(_)
 			| RuntimeCall::OrmlExtension(_)
 			| RuntimeCall::TreasuryBuyoutExtension(_)
+			| RuntimeCall::MockSkipBlocks(_)
 			| RuntimeCall::RewardDistribution(_) => true, // All pallets are allowed, but exhaustive match is defensive
 			                                              // in the case of adding new pallets.
 		}
@@ -1413,6 +1414,18 @@ impl pallet_proxy::Config for Runtime {
 	type AnnouncementDepositFactor = AnnouncementDepositFactor;
 }
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "instant-seal")] {
+        impl pallet_mock_skip_blocks::Config for Runtime {
+            type RuntimeEvent = RuntimeEvent;
+        }
+    } else {
+        impl pallet_mock_skip_blocks::dummy::Config for Runtime {
+			type RuntimeEvent = RuntimeEvent;
+		}
+    }
+}
+
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
 where
 	RuntimeCall: From<C>,
@@ -1507,6 +1520,7 @@ construct_runtime!(
 		// Asset Metadata
 		AssetRegistry: orml_asset_registry::{Pallet, Storage, Call, Event<T>, Config<T>} = 91,
 
+        MockSkipBlocks: pallet_mock_skip_blocks::{Pallet, Call, Storage, Event<T>} = 92,
 	}
 );
 

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -1415,15 +1415,15 @@ impl pallet_proxy::Config for Runtime {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "instant-seal")] {
-        impl pallet_mock_skip_blocks::Config for Runtime {
-            type RuntimeEvent = RuntimeEvent;
-        }
-    } else {
-        impl pallet_mock_skip_blocks::dummy::Config for Runtime {
+	if #[cfg(feature = "instant-seal")] {
+		impl pallet_mock_skip_blocks::Config for Runtime {
 			type RuntimeEvent = RuntimeEvent;
 		}
-    }
+	} else {
+		impl pallet_mock_skip_blocks::dummy::Config for Runtime {
+			type RuntimeEvent = RuntimeEvent;
+		}
+	}
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
@@ -1520,7 +1520,7 @@ construct_runtime!(
 		// Asset Metadata
 		AssetRegistry: orml_asset_registry::{Pallet, Storage, Call, Event<T>, Config<T>} = 91,
 
-        MockSkipBlocks: pallet_mock_skip_blocks::{Pallet, Call, Storage, Event<T>} = 92,
+		MockSkipBlocks: pallet_mock_skip_blocks::{Pallet, Call, Storage, Event<T>} = 92,
 	}
 );
 


### PR DESCRIPTION
This PR introduces a new pallet used to mock block skipping when testing wasm-deploy.
The idea behind it is described in [this](https://github.com/pendulum-chain/pendulum/issues/486) ticket in detail. 
I'll add a broader description before marking the PR as ready for review.

Closes #486. 