### PR TITLE
Set version to `1.1.0` in all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "4436e0292ab1bb631b42973c61205e704475fe8126af845c8d923c0996328127"
 
 [[package]]
 name = "amplitude-runtime"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "bifrost-farming",
  "bifrost-farming-rpc-runtime-api",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "chain-extension-common"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "foucoco-runtime"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "bifrost-farming",
  "bifrost-farming-rpc-runtime-api",
@@ -6888,7 +6888,7 @@ dependencies = [
 
 [[package]]
 name = "module-pallet-staking-rpc"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -6901,7 +6901,7 @@ dependencies = [
 
 [[package]]
 name = "module-pallet-staking-rpc-runtime-api"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "frame-support",
  "module-oracle-rpc-runtime-api",
@@ -7495,7 +7495,7 @@ dependencies = [
 
 [[package]]
 name = "orml-currencies-allowance-extension"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7570,7 +7570,7 @@ dependencies = [
 
 [[package]]
 name = "orml-tokens-management-extension"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9069,7 +9069,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-staking"
-version = "1.7.2"
+version = "1.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9330,7 +9330,7 @@ dependencies = [
 
 [[package]]
 name = "pendulum-node"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "amplitude-runtime",
  "bifrost-farming-rpc",
@@ -9414,7 +9414,7 @@ dependencies = [
 
 [[package]]
 name = "pendulum-runtime"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "bifrost-farming",
  "bifrost-farming-rpc-runtime-api",
@@ -11058,7 +11058,7 @@ dependencies = [
 
 [[package]]
 name = "price-chain-extension"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "chain-extension-common",
  "dia-oracle",
@@ -11933,7 +11933,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-common"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "cumulus-primitives-core",
  "dia-oracle",
@@ -11959,7 +11959,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "amplitude-runtime",
  "asset-hub-kusama-runtime",
@@ -15528,7 +15528,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-chain-extension"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "chain-extension-common",
  "frame-support",
@@ -15858,7 +15858,7 @@ dependencies = [
 
 [[package]]
 name = "treasury-buyout-extension"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -16173,7 +16173,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vesting-manager"
-version = "0.0.1"
+version = "1.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/chain-extensions/common/Cargo.toml
+++ b/chain-extensions/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-extension-common"
-version = "0.1.0"
+version = "1.1.0"
 authors = ["Pendulum"]
 description = "Chain Extension common definitions"
 edition = "2021"

--- a/chain-extensions/price/Cargo.toml
+++ b/chain-extensions/price/Cargo.toml
@@ -3,7 +3,7 @@ name = "price-chain-extension"
 description = "Chain extensions for price info"
 authors = ["Pendulum"]
 edition = "2021"
-version = "0.1.0"
+version = "1.1.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/chain-extensions/token/Cargo.toml
+++ b/chain-extensions/token/Cargo.toml
@@ -3,7 +3,7 @@ name = "token-chain-extension"
 description = "Chain extensions for tokens pallet"
 authors = ["Pendulum"]
 edition = "2021"
-version = "0.1.0"
+version = "1.1.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pendulum-node"
-version = "0.1.0"
+version = "1.1.0"
 authors = ["Pendulum"]
 description = "The Pendulum/Amplitude collator node"
 homepage = "https://pendulumchain.org"
@@ -76,19 +76,19 @@ polkadot-service = { git = "https://github.com/paritytech/polkadot-sdk", branch 
 staging-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 # Cumulus
-cumulus-client-cli =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-cumulus-client-consensus-aura =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-cumulus-client-consensus-common =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-cumulus-client-consensus-proposer =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-cumulus-client-collator =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-cumulus-client-network =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-cumulus-client-service =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-cumulus-primitives-core =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-cumulus-primitives-parachain-inherent =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-cumulus-relay-chain-inprocess-interface =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-cumulus-relay-chain-interface =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-cumulus-relay-chain-rpc-interface =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-cumulus-relay-chain-minimal-node =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-client-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-client-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-client-consensus-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-client-consensus-proposer = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-client-collator = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-client-network = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-client-service = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-relay-chain-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 #bifrost
 bifrost-farming-rpc = { git = "https://github.com/bifrost-finance/bifrost", rev = "46ba3689c2fe1011cce0d752cb479e0e522e2e76" }

--- a/pallets/orml-currencies-allowance-extension/Cargo.toml
+++ b/pallets/orml-currencies-allowance-extension/Cargo.toml
@@ -2,13 +2,13 @@
 authors = ["Pendulum Chain"]
 edition = "2021"
 name = "orml-currencies-allowance-extension"
-version = "1.0.0"
+version = "1.1.0"
 
 [dependencies]
-codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"]}
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"]}
-serde = {version = "1.0.136", default-features = false, features = ["derive"]}
-sha2 = {version = "0.8.2", default-features = false}
+codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.136", default-features = false, features = ["derive"] }
+sha2 = { version = "0.8.2", default-features = false }
 
 # Substrate dependencies
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
@@ -26,27 +26,27 @@ pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch =
 
 [dev-dependencies]
 mocktopus = "0.8.0"
-frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
+frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
 
-pallet-balances = {git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 
 [features]
 default = ["std"]
 std = [
-  "serde/std",
-  "codec/std",
-  "sha2/std",
-  "sp-core/std",
-  "sp-std/std",
-  "sp-runtime/std",
-  "frame-support/std",
-  "frame-system/std",
-  "orml-currencies/std",
-  "orml-tokens/std",
-  "orml-traits/std",
-  "frame-benchmarking/std"
+    "serde/std",
+    "codec/std",
+    "sha2/std",
+    "sp-core/std",
+    "sp-std/std",
+    "sp-runtime/std",
+    "frame-support/std",
+    "frame-system/std",
+    "orml-currencies/std",
+    "orml-tokens/std",
+    "orml-traits/std",
+    "frame-benchmarking/std"
 ]
 
 runtime-benchmarks = [

--- a/pallets/orml-tokens-management-extension/Cargo.toml
+++ b/pallets/orml-tokens-management-extension/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Pendulum Chain"]
 edition = "2021"
 name = "orml-tokens-management-extension"
-version = "1.0.0"
+version = "1.1.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"] }
@@ -28,7 +28,7 @@ orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 [dev-dependencies]
 mocktopus = "0.8.0"
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.1.0"}
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.1.0" }
 pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 # Spacewalk libraries
 spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "580dd307ede65f90f17df6731645b678f3596e0f" }

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -3,62 +3,62 @@ authors = ["KILT <info@kilt.io>"]
 description = "Parachain parachain-staking pallet for collator delegation and selection as well as reward distribution"
 edition = "2021"
 name = "parachain-staking"
-version = "1.7.2"
+version = "1.1.0"
 
 [dev-dependencies]
-pallet-aura =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
-pallet-timestamp =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
-sp-consensus-aura =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
-sp-core =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
-sp-io =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
+pallet-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 [dependencies]
 log = { version = "0.4.17", default-features = false }
-parity-scale-codec = {version = "3.1.5", default-features = false, features = ["derive"]}
-scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
-serde = {version = "1.0.142", default-features = false}
+parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+serde = { version = "1.0.142", default-features = false }
 serde_derive = { version = "1.0.117" }
-sp-api =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
 module-pallet-staking-rpc-runtime-api = { path = "./rpc/runtime-api", default-features = false }
 
-frame-support =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
-frame-system =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
-pallet-authorship =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
-pallet-balances =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
-pallet-session =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
-sp-runtime =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
-sp-staking =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
-sp-std =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
-sp-arithmetic =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+pallet-authorship = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
 
 # benchmarking
-frame-benchmarking =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, optional = true}
+frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, optional = true }
 
 [features]
 default = ["std"]
 runtime-benchmarks = [
-  "frame-benchmarking/runtime-benchmarks",
-  "frame-support/runtime-benchmarks",
-  "frame-system/runtime-benchmarks",
-  "pallet-balances/runtime-benchmarks",
+    "frame-benchmarking/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "pallet-balances/runtime-benchmarks",
 ]
 std = [
-  "serde/std",
-  "frame-support/std",
-  "frame-system/std",
-  "log/std",
-  "module-pallet-staking-rpc-runtime-api/std",
-  "pallet-authorship/std",
-  "pallet-balances/std",
-  "pallet-session/std",
-  "parity-scale-codec/std",
-  "scale-info/std",
-  "sp-api/std",
-  "sp-runtime/std",
-  "sp-staking/std",
-  "sp-std/std",
-  "sp-arithmetic/std"
+    "serde/std",
+    "frame-support/std",
+    "frame-system/std",
+    "log/std",
+    "module-pallet-staking-rpc-runtime-api/std",
+    "pallet-authorship/std",
+    "pallet-balances/std",
+    "pallet-session/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "sp-api/std",
+    "sp-runtime/std",
+    "sp-staking/std",
+    "sp-std/std",
+    "sp-arithmetic/std"
 ]
 try-runtime = [
-  "frame-support/try-runtime",
+    "frame-support/try-runtime",
 ]

--- a/pallets/parachain-staking/rpc/Cargo.toml
+++ b/pallets/parachain-staking/rpc/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Pendulum"]
 edition = "2021"
 name = "module-pallet-staking-rpc"
-version = "1.0.0"
+version = "1.1.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }

--- a/pallets/parachain-staking/rpc/runtime-api/Cargo.toml
+++ b/pallets/parachain-staking/rpc/runtime-api/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Pendulum"]
 edition = "2021"
 name = "module-pallet-staking-rpc-runtime-api"
-version = "1.0.0"
+version = "1.1.0"
 
 [dependencies]
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
@@ -12,7 +12,7 @@ parity-scale-codec = { version = "3.1.5", default-features = false, features = [
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "580dd307ede65f90f17df6731645b678f3596e0f" }
 serde = { version = "1.0.142", default-features = false, features = ["derive"] }
-sp-arithmetic =  { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/pallets/treasury-buyout-extension/Cargo.toml
+++ b/pallets/treasury-buyout-extension/Cargo.toml
@@ -2,12 +2,12 @@
 authors = ["Pendulum Chain"]
 edition = "2021"
 name = "treasury-buyout-extension"
-version = "1.0.0"
+version = "1.1.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.130",  default-features = false, features = ["derive"]}
+serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 sha2 = { version = "0.8.2", default-features = false }
 
 # Substrate dependencies
@@ -29,11 +29,11 @@ spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", de
 
 [dev-dependencies]
 mocktopus = "0.8.0"
-frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
+frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
 xcm = { git = "https://github.com/paritytech/polkadot-sdk", package = "staging-xcm", branch = "release-polkadot-v1.1.0" }
 
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "580dd307ede65f90f17df6731645b678f3596e0f" }
 runtime-common = { path = "../../runtime/common", default-features = false }

--- a/pallets/vesting-manager/Cargo.toml
+++ b/pallets/vesting-manager/Cargo.toml
@@ -3,13 +3,13 @@ authors = ["Pendulum"]
 description = "A pallet to manage vesting schedules"
 edition = "2021"
 name = "vesting-manager"
-version = "0.0.1"
+version = "1.1.0"
 
 [dependencies]
 log = { version = "0.4.17", default-features = false }
-parity-scale-codec = {version = "3.1.5", default-features = false, features = ["derive"]}
-scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
-serde = {version = "1.0.142", default-features = false, optional = true}
+parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+serde = { version = "1.0.142", default-features = false, optional = true }
 sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
 
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
@@ -19,28 +19,28 @@ sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "rel
 sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
 
 # benchmarking
-frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, optional = true}
+frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, optional = true }
 
 [features]
 default = ["std"]
 runtime-benchmarks = [
-  "frame-benchmarking",
-  "frame-support/runtime-benchmarks",
-  "frame-system/runtime-benchmarks",
-  "pallet-vesting/runtime-benchmarks"
+    "frame-benchmarking",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "pallet-vesting/runtime-benchmarks"
 ]
 std = [
-  "frame-support/std",
-  "frame-system/std",
-  "log/std",
-  "parity-scale-codec/std",
-  "pallet-vesting/std",
-  "scale-info/std",
-  "serde/std",
-  "sp-api/std",
-  "sp-runtime/std",
-  "sp-std/std",
+    "frame-support/std",
+    "frame-system/std",
+    "log/std",
+    "parity-scale-codec/std",
+    "pallet-vesting/std",
+    "scale-info/std",
+    "serde/std",
+    "sp-api/std",
+    "sp-runtime/std",
+    "sp-std/std",
 ]
 try-runtime = [
-  "frame-support/try-runtime",
+    "frame-support/try-runtime",
 ]

--- a/runtime/amplitude/Cargo.toml
+++ b/runtime/amplitude/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 homepage = "https://pendulumchain.org"
 name = "amplitude-runtime"
 repository = "https://github.com/pendulum-chain/pendulum"
-version = "0.1.0"
+version = "1.1.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
+substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 [dependencies]
 cfg-if = "1.0.0"
@@ -22,7 +22,7 @@ log = { version = "0.4.17", default-features = false }
 paste = "1.0.14"
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.144", default-features = false, features = ["derive"] }
-smallvec = {version = "1.9.0"}
+smallvec = { version = "1.9.0" }
 
 # Local
 runtime-common = { path = "../common", default-features = false }
@@ -257,7 +257,6 @@ std = [
     "vesting-manager/std",
     "price-chain-extension/std",
     "token-chain-extension/std",
-
 ]
 
 runtime-benchmarks = [

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-common"
-version = "0.1.0"
+version = "1.1.0"
 authors = ["Pendulum"]
 description = "Pendulum runtime common"
 homepage = "https://pendulumchain.org"

--- a/runtime/foucoco/Cargo.toml
+++ b/runtime/foucoco/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 homepage = "https://pendulumchain.org"
 name = "foucoco-runtime"
 repository = "https://github.com/pendulum-chain/pendulum"
-version = "0.1.0"
+version = "1.1.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
+substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -3,7 +3,7 @@ name = "runtime-integration-tests"
 description = "Pendulum runtime integration tests"
 authors = ["Pendulum"]
 edition = "2021"
-version = "0.1.0"
+version = "1.1.0"
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
@@ -24,7 +24,7 @@ sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "rel
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 sp-tracing = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
-xcm = { git = "https://github.com/paritytech/polkadot-sdk", package = "staging-xcm",  branch = "release-polkadot-v1.1.0" }
+xcm = { git = "https://github.com/paritytech/polkadot-sdk", package = "staging-xcm", branch = "release-polkadot-v1.1.0" }
 xcm-executor = { git = "https://github.com/paritytech/polkadot-sdk", package = "staging-xcm-executor", branch = "release-polkadot-v1.1.0" }
 xcm-builder = { git = "https://github.com/paritytech/polkadot-sdk", package = "staging-xcm-builder", branch = "release-polkadot-v1.1.0" }
 pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
@@ -52,15 +52,15 @@ cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/polkado
 parachain-info = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 #staging-parachain-info = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 pallet-message-queue = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-parachain-staking = { path = "../../pallets/parachain-staking"}
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
+parachain-staking = { path = "../../pallets/parachain-staking" }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 asset-hub-polkadot-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 asset-hub-kusama-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 polkadot-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 polkadot-runtime-constants = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
-kusama-runtime = { git = "https://github.com/paritytech/polkadot-sdk", package = "staging-kusama-runtime",  branch = "release-polkadot-v1.1.0" }
+kusama-runtime = { git = "https://github.com/paritytech/polkadot-sdk", package = "staging-kusama-runtime", branch = "release-polkadot-v1.1.0" }
 
 orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0" }
 orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0" }
@@ -72,7 +72,7 @@ orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-l
 pallet-treasury = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 # Local
-runtime-common = { path = "../common" , default-features = false }
+runtime-common = { path = "../common", default-features = false }
 
 pendulum-runtime = { path = "../pendulum" }
 amplitude-runtime = { path = "../amplitude" }

--- a/runtime/pendulum/Cargo.toml
+++ b/runtime/pendulum/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 homepage = "https://pendulumchain.org"
 name = "pendulum-runtime"
 repository = "https://github.com/pendulum-chain/pendulum"
-version = "0.1.0"
+version = "1.1.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0"}
+substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 [dependencies]
 cfg-if = "1.0.0"
@@ -119,11 +119,11 @@ vesting-manager = { path = "../../pallets/vesting-manager", default-features = f
 
 # Polkadot
 pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.1.0" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot-sdk", package = "polkadot-parachain-primitives", default-features = false, branch = "release-polkadot-v1.1.0"}
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot-sdk", package = "polkadot-parachain-primitives", default-features = false, branch = "release-polkadot-v1.1.0" }
 polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.1.0" }
-xcm = { git = "https://github.com/paritytech/polkadot-sdk", package = "staging-xcm", default-features = false , branch = "release-polkadot-v1.1.0" }
+xcm = { git = "https://github.com/paritytech/polkadot-sdk", package = "staging-xcm", default-features = false, branch = "release-polkadot-v1.1.0" }
 xcm-builder = { git = "https://github.com/paritytech/polkadot-sdk", package = "staging-xcm-builder", default-features = false, branch = "release-polkadot-v1.1.0" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot-sdk", package = "staging-xcm-executor", default-features = false , branch = "release-polkadot-v1.1.0"}
+xcm-executor = { git = "https://github.com/paritytech/polkadot-sdk", package = "staging-xcm-executor", default-features = false, branch = "release-polkadot-v1.1.0" }
 
 # Cumulus
 cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.1.0" }


### PR DESCRIPTION
<!-- If you added changes to files in the `node` directory or any other changes that would require a re-deployment of the collator nodes, please add the following line to the PR description:
@pendulum-chain/product: This PR adds changes to the node client code that require a **redeployment of the collator nodes** to take effect. 
Please ensure that the collator nodes are redeployed after this PR is merged.  
-->

This sets the version of _all_ crates defined in the pendulum repository to `1.1.0`. This means, that some crates have major jumps or some versions are even set backward. But IMO it makes sense to have every crate defined with the same version and not just the `node` because every crate was updated to use the polkadot v1.1.0 dependencies so the version of every crate should reflect that.

<!-- Replace xx with the issue number that is fixed by this pull request. -->
Closes #492. 