### PR TITLE
release: Bump pendulum spec version to 19

### DIFF
--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -256,7 +256,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("pendulum"),
 	impl_name: create_runtime_str!("pendulum"),
 	authoring_version: 1,
-	spec_version: 18,
+	spec_version: 19,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 10,


### PR DESCRIPTION
<!-- If you added changes to files in the `node` directory or any other changes that would require a re-deployment of the collator nodes, please add the following line to the PR description:
@pendulum-chain/product: This PR adds changes to the node client code that require a **redeployment of the collator nodes** to take effect. 
Please ensure that the collator nodes are redeployed after this PR is merged.  
-->
Bumps the spec version of the pendulum runtime to 19. While this effectively makes us skip one version (18), we should still bump it to 19 to make it coherent as that's the version currently live on Amplitude.

Closing this will automatically trigger a release pipeline that builds the artifact and creates the github release, see [this](https://github.com/pendulum-chain/pendulum/blob/main/.github/workflows/release.yml).

<!-- Replace xx with the issue number that is fixed by this pull request. -->
Related to https://github.com/pendulum-chain/tasks/issues/329. 