### PR TITLE
Use truly free balance (liquid) in chain extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15564,6 +15564,7 @@ dependencies = [
  "orml-currencies-allowance-extension",
  "orml-tokens",
  "orml-traits",
+ "pallet-balances",
  "pallet-contracts",
  "parity-scale-codec",
  "sp-core",

--- a/chain-extensions/token/Cargo.toml
+++ b/chain-extensions/token/Cargo.toml
@@ -21,6 +21,7 @@ sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", default-featu
 sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
 sp-tracing = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.1.0" }
 sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.1.0" }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.1.0" }
 pallet-contracts = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.1.0" }
 
 # Open Runtime Module Library
@@ -56,4 +57,5 @@ std = [
     "spacewalk-primitives/std",
     "chain-extension-common/std",
     "sp-std/std",
+    "pallet-balances/std"
 ]

--- a/chain-extensions/token/src/lib.rs
+++ b/chain-extensions/token/src/lib.rs
@@ -17,6 +17,7 @@ use pallet_contracts::chain_extension::{
 	ChainExtension, Environment, Ext, InitState, RetVal, SysConfig,
 };
 use sp_core::crypto::UncheckedFrom;
+use sp_std::vec::Vec;
 use sp_runtime::DispatchError;
 use sp_tracing::{error, trace};
 use sp_weights::Weight;

--- a/chain-extensions/token/src/lib.rs
+++ b/chain-extensions/token/src/lib.rs
@@ -183,7 +183,6 @@ where
 	let balance_encoded: Vec<u8> = if currency_id == T::GetNativeCurrencyId::get() {
 		<pallet_balances::Pallet<T> as fungible::Inspect<T::AccountId>>::reducible_balance(&account_id, Preservation::Preserve, Fortitude::Polite).encode()
 	} else {
-
 		<orml_tokens::Pallet<T> as fungibles::Inspect<T::AccountId>>::reducible_balance(currency_id, &account_id, Preservation::Preserve, Fortitude::Polite).encode()
 	};
 

--- a/chain-extensions/token/src/lib.rs
+++ b/chain-extensions/token/src/lib.rs
@@ -7,6 +7,7 @@ use frame_support::{
 	pallet_prelude::{Decode, Get, PhantomData},
 	DefaultNoBound,
 };
+use frame_support::traits::tokens::{fungibles,fungible, Preservation, Fortitude};
 use orml_currencies::WeightInfo;
 use orml_currencies_allowance_extension::{
 	default_weights::WeightInfo as AllowanceWeightInfo, Config as AllowanceConfig,
@@ -19,8 +20,8 @@ use sp_core::crypto::UncheckedFrom;
 use sp_runtime::DispatchError;
 use sp_tracing::{error, trace};
 use sp_weights::Weight;
-use spacewalk_primitives::CurrencyId;
-
+use spacewalk_primitives::{CurrencyId};
+use pallet_balances;
 pub(crate) type BalanceOfForChainExt<T> =
 	<<T as orml_currencies::Config>::MultiCurrency as orml_traits::MultiCurrency<
 		<T as frame_system::Config>::AccountId,
@@ -69,6 +70,7 @@ where
 	T: SysConfig
 		+ orml_tokens::Config<CurrencyId = CurrencyId>
 		+ pallet_contracts::Config
+		+ pallet_balances::Config
 		+ orml_currencies::Config<MultiCurrency = Tokens, AccountId = AccountId>
 		+ orml_currencies_allowance_extension::Config,
 	<T as SysConfig>::AccountId: UncheckedFrom<<T as SysConfig>::Hash> + AsRef<[u8]>,
@@ -154,7 +156,8 @@ where
 	T: SysConfig
 		+ orml_tokens::Config<CurrencyId = CurrencyId>
 		+ pallet_contracts::Config
-		+ orml_currencies::Config<MultiCurrency = Tokens, AccountId = AccountId>
+	+ orml_currencies::Config<MultiCurrency = Tokens, AccountId = AccountId>
+		+ pallet_balances::Config
 		+ orml_currencies_allowance_extension::Config,
 	E: Ext<T = T>,
 	Tokens: orml_traits::MultiCurrency<AccountId, CurrencyId = CurrencyId>,
@@ -177,12 +180,14 @@ where
 		return Ok(RetVal::Converging(ChainExtensionTokenError::Unsupported.as_u32()))
 	}
 
-	let balance = <orml_currencies::Pallet<T> as MultiCurrency<T::AccountId>>::free_balance(
-		currency_id,
-		&account_id,
-	);
+	let balance_encoded: Vec<u8> = if currency_id == T::GetNativeCurrencyId::get() {
+		<pallet_balances::Pallet<T> as fungible::Inspect<T::AccountId>>::reducible_balance(&account_id, Preservation::Preserve, Fortitude::Polite).encode()
+	} else {
 
-	if let Err(_) = env.write(&balance.encode(), false, None) {
+		<orml_tokens::Pallet<T> as fungibles::Inspect<T::AccountId>>::reducible_balance(currency_id, &account_id, Preservation::Preserve, Fortitude::Polite).encode()
+	};
+
+	if let Err(_) = env.write(&balance_encoded, false, None) {
 		return Ok(RetVal::Converging(ChainExtensionOutcome::WriteError.as_u32()))
 	};
 	return Ok(RetVal::Converging(ChainExtensionOutcome::Success.as_u32()))

--- a/zombienet/config.toml
+++ b/zombienet/config.toml
@@ -1,22 +1,23 @@
+[settings]
+timeout = 1000
+
 [relaychain]
-default_command = "../polkadot/target/release/polkadot"
+default_command = "/Users/gianni/root/Pendulum/polkadot-sdk/target/debug/polkadot"
 default_args = [ "-lparachain=debug" ]
 chain = "rococo-local"
 
-  [[relaychain.nodes]]
-  name = "alice"
-  validator = true
+[[relaychain.nodes]]
+name = "alice"
 
-  [[relaychain.nodes]]
-  name = "bob"
-  validator = true
+[[relaychain.nodes]]
+name = "bob"
 
 [[parachains]]
 id = 1000
 cumulus_based = true
 chain = "foucoco" # "pendulum"/"amplitude"/"dev"/"local"
 
-  [parachains.collator]
-  name = "alice"
-  command = "../pendulum/target/release/pendulum-node"
+[parachains.collator]
+name = "alice"
+command = "/Users/gianni/root/Pendulum/pendulum/target/release/pendulum-node"
   

--- a/zombienet/config.toml
+++ b/zombienet/config.toml
@@ -1,16 +1,15 @@
-[settings]
-timeout = 1000
-
 [relaychain]
-default_command = "/Users/gianni/root/Pendulum/polkadot-sdk/target/debug/polkadot"
+default_command = "../polkadot/target/release/polkadot"
 default_args = [ "-lparachain=debug" ]
 chain = "rococo-local"
 
 [[relaychain.nodes]]
 name = "alice"
+validator = true
 
 [[relaychain.nodes]]
 name = "bob"
+validator = true
 
 [[parachains]]
 id = 1000
@@ -19,5 +18,4 @@ chain = "foucoco" # "pendulum"/"amplitude"/"dev"/"local"
 
 [parachains.collator]
 name = "alice"
-command = "/Users/gianni/root/Pendulum/pendulum/target/release/pendulum-node"
-  
+command = "../pendulum/target/release/pendulum-node"


### PR DESCRIPTION
Closes #483 

Uses the `reducible_balance` fn from the `Inspect` trait. This is the truly liquid balance see [here](https://github.com/open-web3-stack/open-runtime-module-library/blob/polkadot-v1.1.0/tokens/src/lib.rs#L1808) of `orml_tokens` and [here](https://github.com/paritytech/polkadot-sdk/blob/release-polkadot-v1.1.0/substrate/frame/balances/src/impl_fungible.rs#L69) for `pallet_balances`.  Here frozen has a different meaning but the meaning of liquid is the same judging by how both use it in their `transfer_all` function.

There is no need to substract from `reserved` since these free and reserved are already mutually exclusive (see the reserve [extrinsic](https://github.com/open-web3-stack/open-runtime-module-library/blob/polkadot-v1.1.0/tokens/src/lib.rs#L1433)).

### Why not use MultiCurrency

Sadly, this trait does not implement the notion of a reducible balance nor of a frozen balance. It does implement this notion in `ensure_can_withdraw` but [this](https://github.com/open-web3-stack/open-runtime-module-library/blob/polkadot-v1.1.0/tokens/src/lib.rs#L736) won't actually tell us the amount, so the `Inspect` trait seems to be the only choice (that I could find). 
But this means we need to match between the native and token variants, which is not very ergonomic. Also, the return is encoded to avoid mismatches of `Balance` type.