### PR TITLE
Bump Foucoco spec version to 22.

### DIFF
--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -254,7 +254,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("foucoco"),
 	impl_name: create_runtime_str!("foucoco"),
 	authoring_version: 1,
-	spec_version: 19,
+	spec_version: 22,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 8,


### PR DESCRIPTION
Related to [tasks/#419](https://github.com/pendulum-chain/tasks/issues/419)

Note: The upgrade was already perform. Due to testing, 2 other releases were performed between `19` and `22`.

Compressed wasm used for the upgrade:
[foucoco_runtime.compact.compressed.wasm.zip](https://github.com/user-attachments/files/18456696/foucoco_runtime.compact.compressed.wasm.zip)


Code hash:
`0x558f535582bcb58e59d4f785a3080ddc3702688ccff4f72c0cedccf5d80dfe72`