### PR TITLE
release: Bump amplitude spec version to 20

### DIFF
--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -256,10 +256,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("amplitude"),
 	impl_name: create_runtime_str!("amplitude"),
 	authoring_version: 1,
-	spec_version: 19,
+	spec_version: 20,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 13,
+	transaction_version: 14,
 	state_version: 1,
 };
 

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -254,7 +254,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("foucoco"),
 	impl_name: create_runtime_str!("foucoco"),
 	authoring_version: 1,
-	spec_version: 19,
+	spec_version: 22,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 8,


### PR DESCRIPTION
Related to [tasks/#419](https://github.com/pendulum-chain/tasks/issues/419).

Both spec and transaction versions are upgraded. For the latter, we know that at least `pallet_balances` has renamed some extrinsics.