### PR TITLE
Fix node compilation

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "1.77.0"
-components = ["rustfmt", "clippy"]
+channel = "1.77.0"
+components = ["rustfmt", "clippy", "rust-src"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
The node compilation fails with

```
$ cargo build --release --quiet
⚡ Found 3 strongly connected components which includes at least one cycle each
cycle(001) ∈ α: DisputeCoordinator ~~{"DisputeDistributionMessage"}~~> DisputeDistribution ~~{"DisputeCoordinatorMessage"}~~>  *
cycle(002) ∈ β: CandidateBacking ~~{"CollatorProtocolMessage"}~~> CollatorProtocol ~~{"CandidateBackingMessage"}~~>  *
cycle(003) ∈ γ: NetworkBridgeRx ~~{"GossipSupportMessage"}~~> GossipSupport ~~{"NetworkBridgeRxMessage"}~~>  *
error: failed to run custom build command for `amplitude-runtime v1.6.0 (/app/prodbuild/pendulum/runtime/amplitude)`
Caused by:
  process didn't exit successfully: `/app/prodbuild/pendulum/target/release/build/amplitude-runtime-[49](https://gitlab.com/pendulumchain/compilation/-/jobs/9011102737#L49)26c6a6f1ea772d/build-script-build` (exit status: 1)
  --- stderr
  Cannot compile the WASM runtime: no standard library sources found!
  You can install them with `rustup component add rust-src` if you're using `rustup`.
error: failed to run custom build command for `pendulum-runtime v1.6.0 (/app/prodbuild/pendulum/runtime/pendulum)`
Caused by:
  process didn't exit successfully: `/app/prodbuild/pendulum/target/release/build/pendulum-runtime-75d6ad216142faa9/build-script-build` (exit status: 1)
  --- stderr
  Cannot compile the WASM runtime: no standard library sources found!
  You can install them with `rustup component add rust-src` if you're using `rustup`.
error: failed to run custom build command for `foucoco-runtime v1.6.0 (/app/prodbuild/pendulum/runtime/foucoco)`
Caused by:
  process didn't exit successfully: `/app/prodbuild/pendulum/target/release/build/foucoco-runtime-06f4fcc6ef2[56](https://gitlab.com/pendulumchain/compilation/-/jobs/9011102737#L56)f6f/build-script-build` (exit status: 1)
  --- stderr
  Cannot compile the WASM runtime: no standard library sources found!
  You can install them with `rustup component add rust-src` if you're using `rustup`.
```

To fix it, we add `rust-src` to the `components` field of the `rust-toolchain.toml`. 