### PR TITLE
Bump Foucoco spec version to 23.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "4436e0292ab1bb631b42973c61205e704475fe8126af845c8d923c0996328127"
 
 [[package]]
 name = "amplitude-runtime"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "bifrost-farming",
  "bifrost-farming-rpc-runtime-api",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "chain-extension-common"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1771,8 +1771,8 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clients-info"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2771,8 +2771,8 @@ dependencies = [
 
 [[package]]
 name = "currency"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3646,8 +3646,8 @@ dependencies = [
 
 [[package]]
 name = "fee"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "foucoco-runtime"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "bifrost-farming",
  "bifrost-farming-rpc-runtime-api",
@@ -5304,8 +5304,8 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "issue"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "currency",
  "fee",
@@ -6544,8 +6544,8 @@ dependencies = [
 
 [[package]]
 name = "module-issue-rpc"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "jsonrpsee",
  "module-issue-rpc-runtime-api",
@@ -6557,8 +6557,8 @@ dependencies = [
 
 [[package]]
 name = "module-issue-rpc-runtime-api"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6568,8 +6568,8 @@ dependencies = [
 
 [[package]]
 name = "module-oracle-rpc"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -6582,8 +6582,8 @@ dependencies = [
 
 [[package]]
 name = "module-oracle-rpc-runtime-api"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6596,7 +6596,7 @@ dependencies = [
 
 [[package]]
 name = "module-pallet-staking-rpc"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -6609,7 +6609,7 @@ dependencies = [
 
 [[package]]
 name = "module-pallet-staking-rpc-runtime-api"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "frame-support",
  "module-oracle-rpc-runtime-api",
@@ -6623,8 +6623,8 @@ dependencies = [
 
 [[package]]
 name = "module-redeem-rpc"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "jsonrpsee",
  "module-redeem-rpc-runtime-api",
@@ -6636,8 +6636,8 @@ dependencies = [
 
 [[package]]
 name = "module-redeem-rpc-runtime-api"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6647,8 +6647,8 @@ dependencies = [
 
 [[package]]
 name = "module-replace-rpc"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "jsonrpsee",
  "module-replace-rpc-runtime-api",
@@ -6660,8 +6660,8 @@ dependencies = [
 
 [[package]]
 name = "module-replace-rpc-runtime-api"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6671,8 +6671,8 @@ dependencies = [
 
 [[package]]
 name = "module-vault-registry-rpc"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "jsonrpsee",
  "module-oracle-rpc-runtime-api",
@@ -6685,8 +6685,8 @@ dependencies = [
 
 [[package]]
 name = "module-vault-registry-rpc-runtime-api"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "frame-support",
  "module-oracle-rpc-runtime-api",
@@ -6979,8 +6979,8 @@ dependencies = [
 
 [[package]]
 name = "nomination"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "currency",
  "fee",
@@ -7148,8 +7148,8 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "oracle"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "currency",
  "dia-oracle",
@@ -7251,7 +7251,7 @@ dependencies = [
 
 [[package]]
 name = "orml-currencies-allowance-extension"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7307,7 +7307,7 @@ dependencies = [
 
 [[package]]
 name = "orml-tokens-management-extension"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8589,7 +8589,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-staking"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8813,7 +8813,7 @@ dependencies = [
 
 [[package]]
 name = "pendulum-node"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "amplitude-runtime",
  "bifrost-farming-rpc",
@@ -8899,7 +8899,7 @@ dependencies = [
 
 [[package]]
 name = "pendulum-runtime"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "bifrost-farming",
  "bifrost-farming-rpc-runtime-api",
@@ -10325,8 +10325,8 @@ dependencies = [
 
 [[package]]
 name = "pooled-rewards"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10410,7 +10410,7 @@ dependencies = [
 
 [[package]]
 name = "price-chain-extension"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "chain-extension-common",
  "dia-oracle",
@@ -10853,8 +10853,8 @@ dependencies = [
 
 [[package]]
 name = "redeem"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "currency",
  "fee",
@@ -10996,8 +10996,8 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "replace"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "currency",
  "fee",
@@ -11032,8 +11032,8 @@ dependencies = [
 
 [[package]]
 name = "reward-distribution"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -11282,7 +11282,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-common"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -12972,8 +12972,8 @@ dependencies = [
 
 [[package]]
 name = "security"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14706,8 +14706,8 @@ dependencies = [
 
 [[package]]
 name = "spacewalk-primitives"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "base58",
  "frame-support",
@@ -14856,8 +14856,8 @@ dependencies = [
 
 [[package]]
 name = "staking"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14906,8 +14906,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-relay"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "base64 0.13.1",
  "frame-benchmarking",
@@ -15070,7 +15070,7 @@ dependencies = [
 [[package]]
 name = "substrate-stellar-sdk"
 version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/substrate-stellar-sdk?branch=polkadot-v1.6.0#b7b73a5f13c3740c59cb216144012bd421749104"
+source = "git+https://github.com/pendulum-chain/substrate-stellar-sdk?rev=9ab1d0f08de8a543631e77d6b096dd2874216acc#9ab1d0f08de8a543631e77d6b096dd2874216acc"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -15451,7 +15451,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-chain-extension"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "chain-extension-common",
  "frame-support",
@@ -15755,7 +15755,7 @@ dependencies = [
 
 [[package]]
 name = "treasury-buyout-extension"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -16059,8 +16059,8 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vault-registry"
-version = "1.0.13"
-source = "git+https://github.com/pendulum-chain/spacewalk?rev=70beae689db5c20efc17363397e4353cc60fe347#70beae689db5c20efc17363397e4353cc60fe347"
+version = "1.0.17"
+source = "git+https://github.com/pendulum-chain/spacewalk?rev=2a7e61e347b2c1833f9b173c8a4ca422577a1cce#2a7e61e347b2c1833f9b173c8a4ca422577a1cce"
 dependencies = [
  "currency",
  "fee",
@@ -16097,7 +16097,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesting-manager"
-version = "1.6.0-a"
+version = "1.6.0-b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,32 +174,32 @@ substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-s
 substrate-wasm-builder = { git = "https://github.com/paritytech//polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false }
 
 # Spacewalk
-module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
+module-oracle-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+module-issue-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+module-redeem-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+module-replace-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+module-vault-registry-rpc-runtime-api = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+module-issue-rpc = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+module-oracle-rpc = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+module-redeem-rpc = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+module-replace-rpc = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+module-vault-registry-rpc = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
 
-spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
-reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "70beae689db5c20efc17363397e4353cc60fe347" }
+spacewalk-primitives = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+clients-info = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+currency = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+security = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+staking = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+oracle = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+stellar-relay = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+fee = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+vault-registry = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+redeem = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+issue = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+nomination = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+replace = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+pooled-rewards = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
+reward-distribution = { git = "https://github.com/pendulum-chain/spacewalk", default-features = false, rev = "2a7e61e347b2c1833f9b173c8a4ca422577a1cce" }
 
 # Zenlink
 zenlink-protocol = { git = "https://github.com/pendulum-chain/Zenlink-DEX-Module", default-features = false, branch = "release-polkadot-v1.6.0" }

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -232,7 +232,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("foucoco"),
 	impl_name: create_runtime_str!("foucoco"),
 	authoring_version: 1,
-	spec_version: 22,
+	spec_version: 23,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 8,


### PR DESCRIPTION
This update contains the new Stellar types generated [here](https://github.com/pendulum-chain/substrate-stellar-sdk/pull/40).

Compressed runtime: [foucoco_runtime.compact.compressed.wasm.zip](https://github.com/user-attachments/files/20460260/foucoco_runtime.compact.compressed.wasm.zip)

Code hash: `0xbf8d90a56d5471707b604818d53c3e06587a66b4578466a4a7f1362dfb93f41e`.
