### PR TITLE
Bump to spec 24.

### DIFF
--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -232,7 +232,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("foucoco"),
 	impl_name: create_runtime_str!("foucoco"),
 	authoring_version: 1,
-	spec_version: 23,
+	spec_version: 24,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 8,


### PR DESCRIPTION
Code hash: `0x5197156279431bef4e617d495ba614d8f0498eff850ce2c4467ea244873faf57`.

Wasm compressed: 
[foucoco_runtime.compact.compressed.wasm.zip](https://github.com/user-attachments/files/20551403/foucoco_runtime.compact.compressed.wasm.zip)
