### PR TITLE
release: Bump amplitude spec version to 20

### DIFF
--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -231,7 +231,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("amplitude"),
 	impl_name: create_runtime_str!("amplitude"),
 	authoring_version: 1,
-	spec_version: 20,
+	spec_version: 21,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 14,


### PR DESCRIPTION

### Context
Adds `polkadot-sdk` latest [fix](https://github.com/paritytech/polkadot-sdk/commit/e36ffb3da50afff65f8ec99378fbfe14f9d340e7), as well as [new](https://github.com/pendulum-chain/spacewalk/pull/583) Spacewalk types used on the runtime's pallets.