### PR TITLE
release: Bump pendulum spec version to 21

### DIFF
--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -234,7 +234,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("pendulum"),
 	impl_name: create_runtime_str!("pendulum"),
 	authoring_version: 1,
-	spec_version: 20,
+	spec_version: 21,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 11,


### PR DESCRIPTION
Bumps the pendulum spec version to 21 to prepare the next runtime upgrade. 