### PR TITLE
Bump Foucoco spec version to 25

### DIFF
--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -232,7 +232,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("foucoco"),
 	impl_name: create_runtime_str!("foucoco"),
 	authoring_version: 1,
-	spec_version: 24,
+	spec_version: 25,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 8,


### PR DESCRIPTION
This update contains fixes for Stellar type changes as well as a potential fix for the synchronization issue of the node after the `1.6.0` update.

Compressed runtime: 
[foucoco_runtime.compact.compressed.wasm.zip](https://github.com/user-attachments/files/21415715/foucoco_runtime.compact.compressed.wasm.zip)

Code hash: `0x928d263f4b9e15d9c3a9fe3daf031c8eb9b880ffa6b9de6c1355309b4f44e036`.