### PR TITLE
release: Bump amplitude spec version to 22

### DIFF
--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -231,7 +231,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("amplitude"),
 	impl_name: create_runtime_str!("amplitude"),
 	authoring_version: 1,
-	spec_version: 21,
+	spec_version: 22,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 14,


### PR DESCRIPTION
Bumps the amplitude spec version to 22 to prepare the next runtime upgrade.