### PR TITLE
release: Bump amplitude spec version to 23

### DIFF
--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -231,7 +231,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("amplitude"),
 	impl_name: create_runtime_str!("amplitude"),
 	authoring_version: 1,
-	spec_version: 22,
+	spec_version: 23,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 14,
@@ -2111,7 +2111,6 @@ impl_runtime_apis! {
 	}
 
 }
-
 
 cumulus_pallet_parachain_system::register_validate_block! {
 	Runtime = Runtime,


### PR DESCRIPTION
Adds changes to pay out the collator rewards from treasury and adds Assethub as a reserve for the relay token. 

<!-- If you added changes to files in the `node` directory or any other changes that would require a re-deployment of the collator nodes, please add the following line to the PR description:
@pendulum-chain/product: This PR adds changes to the node client code that require a **redeployment of the collator nodes** to take effect. 
Please ensure that the collator nodes are redeployed after this PR is merged.  
-->

