### PR TITLE
release: Keep relay chain as a reserve and bump amplitude and pendulum spec version to 24

### DIFF
--- a/runtime/amplitude/src/lib.rs
+++ b/runtime/amplitude/src/lib.rs
@@ -231,7 +231,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("amplitude"),
 	impl_name: create_runtime_str!("amplitude"),
 	authoring_version: 1,
-	spec_version: 23,
+	spec_version: 24,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 14,

--- a/runtime/amplitude/src/xcm_config.rs
+++ b/runtime/amplitude/src/xcm_config.rs
@@ -81,17 +81,6 @@ where
 			return true;
 		}
 
-		// Explicit deny for KSM from Relay Chain
-		if matches!(
-			asset,
-			MultiAsset {
-				id: Concrete(MultiLocation { parents: 1, interior: Here }),
-				fun: Fungible(_),
-			}
-		) && matches!(origin, MultiLocation { parents: 1, interior: Here })
-		{
-			return false;
-		}
 
 		if let Some(ref reserve) = ReserveProvider::reserve(asset) {
 			if reserve == origin {

--- a/runtime/foucoco/src/lib.rs
+++ b/runtime/foucoco/src/lib.rs
@@ -232,7 +232,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("foucoco"),
 	impl_name: create_runtime_str!("foucoco"),
 	authoring_version: 1,
-	spec_version: 26,
+	spec_version: 27,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 8,

--- a/runtime/foucoco/src/xcm_config.rs
+++ b/runtime/foucoco/src/xcm_config.rs
@@ -76,18 +76,6 @@ where
 			return true;
 		}
 
-		// Explicit deny for PAS from Relay Chain
-		if matches!(
-			asset,
-			MultiAsset {
-				id: Concrete(MultiLocation { parents: 1, interior: Here }),
-				fun: Fungible(_),
-			}
-		) && matches!(origin, MultiLocation { parents: 1, interior: Here })
-		{
-			return false;
-		}
-
 		if let Some(ref reserve) = ReserveProvider::reserve(asset) {
 			if reserve == origin {
 				return true;

--- a/runtime/pendulum/src/lib.rs
+++ b/runtime/pendulum/src/lib.rs
@@ -234,7 +234,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("pendulum"),
 	impl_name: create_runtime_str!("pendulum"),
 	authoring_version: 1,
-	spec_version: 23,
+	spec_version: 24,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 11,

--- a/runtime/pendulum/src/xcm_config.rs
+++ b/runtime/pendulum/src/xcm_config.rs
@@ -86,18 +86,6 @@ where
 			return true;
 		}
 
-		// Explicit deny for DOT from Relay Chain
-		if matches!(
-			asset,
-			MultiAsset {
-				id: Concrete(MultiLocation { parents: 1, interior: Here }),
-				fun: Fungible(_),
-			}
-		) && matches!(origin, MultiLocation { parents: 1, interior: Here })
-		{
-			return false;
-		}
-
 		if let Some(ref reserve) = ReserveProvider::reserve(asset) {
 			if reserve == origin {
 				return true;


### PR DESCRIPTION
<!-- If you added changes to files in the `node` directory or any other changes that would require a re-deployment of the collator nodes, please add the following line to the PR description:
@pendulum-chain/product: This PR adds changes to the node client code that require a **redeployment of the collator nodes** to take effect. 
Please ensure that the collator nodes are redeployed after this PR is merged.  
-->

<!-- Replace xx with the issue number that is fixed by this pull request. -->
This pull request updates the runtime versions for the `amplitude`, `foucoco`, and `pendulum` chains and removes explicit asset transfer denials from their XCM configuration files. The changes streamline the asset transfer logic and ensure the runtime versions reflect these updates.

**Runtime Version Updates:**
- Bumped `spec_version` for `amplitude` from 23 to 24 in `runtime/amplitude/src/lib.rs`.
- Bumped `spec_version` for `foucoco` from 26 to 27 in `runtime/foucoco/src/lib.rs`.
- Bumped `spec_version` for `pendulum` from 23 to 24 in `runtime/pendulum/src/lib.rs`.

**XCM Asset Transfer Logic Simplification:**
- Removed explicit denial of KSM, PAS, and DOT asset transfers from the Relay Chain in the XCM configuration files for `amplitude`, `foucoco`, and `pendulum` respectively, simplifying the logic for asset acceptance. [[1]](diffhunk://#diff-f2b065c9a230c62a9e0320c5dc933302af3fe4c229d63a5432eb109e7a327e71L84-L94) [[2]](diffhunk://#diff-4e8d76261f23472a35cee760b0818583d9267e55b361e44f2c646ab1c031d7d0L79-L90) [[3]](diffhunk://#diff-91848e42611fbf16b8a970242187d57e75083383e231b2a458f8404b2d08e920L89-L100)